### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,24 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+      security-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "security"
+     dev-dependencies:
+        dependency-type: "development"
+    assignees:
+      - "deeprave"
+    reviewers:
+      - "deeprave"
   - package-ecosystem: "github-actions" # GitHub Actions ecosystem
     directory: "/" # Location of workflow files
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Added configuration for Rust dependencies and security updates.

## Summary by Sourcery

Enhance Dependabot configuration by adding grouping for Rust and security updates, limiting open PRs, and setting default assignees and reviewers.

Enhancements:
- Group Rust and security updates into separate Dependabot update groups for clearer dependency categorization
- Define a dev-dependencies group for development-only dependencies
- Set open-pull-requests-limit for both npm (root) and GitHub Actions ecosystems to throttle PR volume
- Automatically assign and request review from deeprave on Dependabot pull requests