### PR TITLE
Rs 27 Improve plugin type safety and eliminate code duplication

### DIFF
--- a/docs/plugin_api/cli_integration.md
+++ b/docs/plugin_api/cli_integration.md
@@ -1,0 +1,623 @@
+# Command Vector and CLI Flag Parsing Documentation
+
+## Overview
+
+The CLI integration system provides a sophisticated command-line interface for plugins through a multi-stage process: command segmentation, plugin activation, and argument parsing. This allows plugins to receive structured command arguments and configuration while maintaining isolation and flexibility.
+
+## Architecture
+
+### Three-Stage CLI Processing
+
+1. **Command Segmentation**: Raw CLI arguments are split into global and plugin-specific segments
+2. **Plugin Activation**: Command segments are matched against plugin functions to activate plugins
+3. **Argument Parsing**: Individual plugins parse their specific arguments using configurable parsers
+
+## Command Segmentation
+
+### CommandSegment Structure
+
+CLI arguments are organised into command segments that represent discrete plugin invocations:
+
+```rust
+pub struct CommandSegment {
+    pub command_name: String,  // Matched plugin function name or alias
+    pub args: Vec<String>,     // Arguments specific to this command
+}
+```
+
+### Segmentation Process
+
+The `CommandSegmenter` splits CLI arguments by command boundaries:
+
+```rust
+// Example CLI input
+repostats --verbose --config app.toml analyse --since 1week export --format json
+
+// Becomes:
+// Global args: ["repostats", "--verbose", "--config", "app.toml"]
+// Command segments:
+[
+    CommandSegment {
+        command_name: "analyse",
+        args: ["--since", "1week"]
+    },
+    CommandSegment {
+        command_name: "export",
+        args: ["--format", "json"]
+    }
+]
+```
+
+### Command Discovery
+
+The segmenter maintains a registry of known commands built from plugin functions:
+
+```rust
+// Collected from all plugin advertised_functions()
+let known_commands = vec![
+    "analyse",     // Primary function name
+    "analyze",     // Function alias
+    "stats",       // Function alias
+    "export",      // Different function
+    "dump",        // Function alias
+];
+```
+
+### Segmentation Algorithm
+
+1. **Global Args Processing**: Skip over global arguments (determined by clap)
+2. **Command Boundary Detection**: Identify known command names in remaining args
+3. **Argument Collection**: Collect arguments between command boundaries
+4. **Segment Creation**: Create `CommandSegment` for each detected command
+
+```rust
+pub fn segment_commands_only(
+    &self,
+    args: &[String],
+    global_args: &[String],
+) -> Result<Vec<CommandSegment>> {
+    // Skip global args, process remaining for command segments
+    let remaining_args = &args[global_args.len()..];
+
+    for arg in remaining_args {
+        if self.is_known_command(arg) {
+            // Start new command segment
+        } else {
+            // Add to current command's arguments
+        }
+    }
+}
+```
+
+## Plugin Activation
+
+### Function Matching Process
+
+The plugin manager matches command segments to plugin functions:
+
+```rust
+// For each command segment
+for segment in command_segments {
+    // Check all plugin functions
+    for function in plugin_functions {
+        // Match primary name or aliases
+        if function.name == segment.command_name ||
+           function.aliases.contains(&segment.command_name) {
+            // Activate plugin with this function
+            active_plugins.push(ActivePluginInfo {
+                plugin_name: plugin_name.clone(),
+                function_name: function.name.clone(),  // Always primary name
+                args: segment.args.clone(),           // Command arguments
+            });
+        }
+    }
+}
+```
+
+### ActivePluginInfo Structure
+
+When plugins are matched and activated, they're recorded as:
+
+```rust
+pub struct ActivePluginInfo {
+    pub plugin_name: String,   // Name of the matched plugin
+    pub function_name: String, // Primary function name (canonical)
+    pub args: Vec<String>,     // Arguments from command segment
+}
+```
+
+**Key Behaviours**:
+- `function_name` always contains primary function name, never aliases
+- `args` preserves exact command arguments from the segment
+- Multiple plugins can be activated from a single CLI invocation
+
+### Activation Examples
+
+```bash
+# Single plugin activation
+repostats dump --format json
+# → ActivePluginInfo { plugin_name: "dump", function_name: "dump", args: ["--format", "json"] }
+
+# Multiple plugin activation
+repostats analyse --since 1week export --type csv
+# → ActivePluginInfo { plugin_name: "statistics", function_name: "analyse", args: ["--since", "1week"] }
+# → ActivePluginInfo { plugin_name: "export", function_name: "export", args: ["--type", "csv"] }
+
+# Using aliases
+repostats analyze --detailed    # "analyze" is alias for "analyse"
+# → ActivePluginInfo { plugin_name: "statistics", function_name: "analyse", args: ["--detailed"] }
+```
+
+## Argument Parsing Systems
+
+### Two-Tier Architecture
+
+Plugins can choose between two argument parsing approaches:
+
+1. **Default Simple Parser**: Basic key-value and flag parsing (`PluginSettings`)
+2. **Advanced clap Parser**: Full-featured CLI parsing with validation (`PluginArgParser`)
+
+### Default Simple Parser (PluginSettings)
+
+#### Basic Usage
+
+```rust
+impl Plugin for MyPlugin {
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig
+    ) -> PluginResult<()> {
+        let settings = PluginSettings::from_cli_args("my_function".to_string(), args.to_vec())?;
+
+        // Access parsed arguments
+        if let Some(format) = settings.get_arg("format") {
+            println!("Format: {}", format);
+        }
+
+        if settings.has_flag("verbose") {
+            println!("Verbose mode enabled");
+        }
+
+        Ok(())
+    }
+}
+```
+
+#### Supported Argument Formats
+
+```bash
+# Key-value pairs (--key=value)
+--format=json --output=/tmp/data --limit=100
+
+# Flags (--flag or -f)
+--verbose --debug -q -v
+
+# Help (automatic)
+--help, -h    # Generates help text and exits
+
+# Mixed usage
+repostats dump --format=json --verbose -q --limit=50
+```
+
+#### Argument Access
+
+```rust
+// Create settings from CLI args
+let settings = PluginSettings::from_cli_args(function_name, args)?;
+
+// Access key-value arguments
+let format = settings.get_arg("format").unwrap_or(&"text".to_string());
+let limit = settings.get_arg("limit")
+    .and_then(|s| s.parse::<usize>().ok())
+    .unwrap_or(10);
+
+// Check flags
+let verbose = settings.has_flag("verbose");
+let debug = settings.has_flag("debug") || settings.has_flag("d");
+
+// Raw access
+let all_args = &settings.args;
+let parsed_args = &settings.parsed_args;  // HashMap<String, String>
+let flags = &settings.flags;              // HashSet<String>
+```
+
+#### Help Text Generation
+
+The default parser automatically generates help text:
+
+```rust
+// Custom help text
+impl PluginSettings {
+    pub fn generate_help_text(&self) -> String {
+        let function_name = self.function.as_deref().unwrap_or("plugin");
+        format!(
+            "Usage: {} [OPTIONS]\n\n\
+             OPTIONS:\n  \
+             -h, --help     Show this help message\n\n\
+             Default plugin arguments parser. Individual plugins may extend this.",
+            function_name
+        )
+    }
+}
+```
+
+### Advanced clap Parser (PluginArgParser)
+
+#### Setup and Usage
+
+```rust
+use crate::plugin::args::{PluginArgParser, PluginConfig, create_format_args};
+
+impl Plugin for AdvancedPlugin {
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig
+    ) -> PluginResult<()> {
+        // Create parser with plugin metadata
+        let parser = PluginArgParser::new(
+            "advanced",
+            "Advanced plugin with sophisticated CLI",
+            "1.0.0"
+        )
+        // Add standard format arguments
+        .args(create_format_args())
+        // Add custom arguments
+        .arg(Arg::new("limit")
+            .long("limit")
+            .value_name("NUMBER")
+            .help("Maximum number of items to process")
+            .value_parser(clap::value_parser!(u32))
+        )
+        .arg(Arg::new("since")
+            .long("since")
+            .value_name("TIMESPEC")
+            .help("Process items since this time")
+            .required(false)
+        );
+
+        // Parse arguments
+        let matches = parser.parse(args)?;
+
+        // Extract values with type safety
+        let limit = matches.get_one::<u32>("limit").unwrap_or(&100);
+        let since = matches.get_one::<String>("since");
+        let format = determine_format(&matches, config);
+
+        println!("Limit: {}, Format: {}", limit, format);
+        if let Some(since_value) = since {
+            println!("Since: {}", since_value);
+        }
+
+        Ok(())
+    }
+}
+```
+
+#### Standard Format Arguments
+
+The system provides pre-built format arguments for consistency:
+
+```rust
+pub fn create_format_args() -> Vec<Arg> {
+    vec![
+        Arg::new("json")
+            .long("json")
+            .action(clap::ArgAction::SetTrue)
+            .help("Output in JSON format")
+            .conflicts_with_all(&["text", "compact"]),
+        Arg::new("text")
+            .long("text")
+            .action(clap::ArgAction::SetTrue)
+            .help("Output in human-readable text format (default)")
+            .conflicts_with_all(&["json", "compact"]),
+        Arg::new("compact")
+            .long("compact")
+            .action(clap::ArgAction::SetTrue)
+            .help("Output in compact single-line format")
+            .conflicts_with_all(&["json", "text"]),
+    ]
+}
+```
+
+#### Format Detection with Configuration
+
+```rust
+pub fn determine_format(matches: &ArgMatches, config: &PluginConfig) -> OutputFormat {
+    // CLI flags take precedence
+    if matches.get_flag("json") { return OutputFormat::Json; }
+    if matches.get_flag("compact") { return OutputFormat::Compact; }
+    if matches.get_flag("text") { return OutputFormat::Text; }
+
+    // Fallback to TOML configuration
+    match config.get_string("default_format", "text").to_lowercase().as_str() {
+        "json" => OutputFormat::Json,
+        "compact" => OutputFormat::Compact,
+        _ => OutputFormat::Text,
+    }
+}
+```
+
+#### Error Handling
+
+The clap parser provides sophisticated error handling:
+
+```rust
+pub fn parse(&self, args: &[String]) -> PluginResult<ArgMatches> {
+    match self.command.clone().try_get_matches_from(full_args) {
+        Ok(matches) => Ok(matches),
+        Err(e) => match e.kind() {
+            clap::error::ErrorKind::DisplayHelp |
+            clap::error::ErrorKind::DisplayVersion => {
+                // Print help/version and exit
+                print!("{}", e);
+                std::process::exit(0);
+            }
+            _ => {
+                // Clean up error message for user
+                let clean_msg = error_msg
+                    .strip_prefix("error: ")
+                    .unwrap_or(&error_msg)
+                    .replace("unexpected argument", "Unknown argument")
+                    .replace(" found", "");
+                Err(PluginError::Generic { message: clean_msg })
+            }
+        }
+    }
+}
+```
+
+## Configuration Integration
+
+### PluginConfig Structure
+
+Plugins receive configuration context during argument parsing:
+
+```rust
+pub struct PluginConfig {
+    pub use_colors: bool,                            // Global color setting
+    pub toml_config: HashMap<String, toml::Value>,   // Plugin-specific TOML config
+}
+```
+
+### Configuration Access
+
+```rust
+impl PluginConfig {
+    // String values with defaults
+    pub fn get_string(&self, key: &str, default: &str) -> String {
+        if let Some(toml::Value::String(s)) = self.toml_config.get(key) {
+            s.clone()
+        } else {
+            default.to_string()
+        }
+    }
+
+    // Boolean values with defaults
+    pub fn get_bool(&self, key: &str, default: bool) -> bool {
+        if let Some(toml::Value::Boolean(b)) = self.toml_config.get(key) {
+            *b
+        } else {
+            default
+        }
+    }
+}
+```
+
+### TOML Integration Example
+
+```toml
+# Configuration file: repostats.toml
+[dump]
+default_format = "json"
+show_headers = true
+max_entries = 1000
+
+[export]
+default_format = "csv"
+include_metadata = false
+```
+
+```rust
+// Plugin receives this configuration
+async fn parse_plugin_arguments(&mut self, args: &[String], config: &PluginConfig) -> PluginResult<()> {
+    let default_format = config.get_string("default_format", "text");
+    let show_headers = config.get_bool("show_headers", false);
+    let max_entries = config.get_string("max_entries", "100")
+        .parse::<usize>()
+        .unwrap_or(100);
+
+    // CLI arguments can override configuration
+    // ...
+}
+```
+
+## Complete Integration Example
+
+### Plugin Implementation
+
+```rust
+use crate::plugin::traits::Plugin;
+use crate::plugin::args::{PluginArgParser, PluginConfig, create_format_args, determine_format};
+
+pub struct ExamplePlugin {
+    format: OutputFormat,
+    limit: u32,
+    verbose: bool,
+}
+
+impl Plugin for ExamplePlugin {
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig
+    ) -> PluginResult<()> {
+        let parser = PluginArgParser::new(
+            "example",
+            "Example plugin demonstrating CLI integration",
+            "1.0.0"
+        )
+        .args(create_format_args())
+        .arg(Arg::new("limit")
+            .long("limit")
+            .short('l')
+            .value_name("N")
+            .help("Limit output to N items")
+            .value_parser(clap::value_parser!(u32))
+        )
+        .arg(Arg::new("verbose")
+            .long("verbose")
+            .short('v')
+            .action(clap::ArgAction::SetTrue)
+            .help("Enable verbose output")
+        );
+
+        let matches = parser.parse(args)?;
+
+        // Extract and store configuration
+        self.format = determine_format(&matches, config);
+        self.limit = matches.get_one::<u32>("limit")
+            .copied()
+            .unwrap_or_else(|| {
+                config.get_string("default_limit", "50")
+                    .parse()
+                    .unwrap_or(50)
+            });
+        self.verbose = matches.get_flag("verbose") || config.get_bool("verbose", false);
+
+        if self.verbose {
+            println!("Plugin configured: format={}, limit={}", self.format, self.limit);
+        }
+
+        Ok(())
+    }
+
+    // ... other plugin methods
+}
+```
+
+### CLI Usage Examples
+
+```bash
+# Using defaults from configuration
+repostats example
+
+# Override format
+repostats example --json
+
+# Complex usage with multiple arguments
+repostats example --limit 25 --verbose --compact
+
+# Using short flags
+repostats example -l 10 -v --json
+
+# Multiple plugins in one command
+repostats example --limit 5 export --format csv
+
+# Global args + plugin args
+repostats --config custom.toml --log-level debug example --verbose --limit 100
+```
+
+### Error Handling Examples
+
+```bash
+# Invalid argument
+$ repostats example --invalid-flag
+Error: Unknown argument '--invalid-flag'
+
+# Help request
+$ repostats example --help
+example 1.0.0
+Example plugin demonstrating CLI integration
+
+USAGE:
+    example [OPTIONS]
+
+OPTIONS:
+    -h, --help               Show help information
+    -v, --verbose            Enable verbose output
+    -l, --limit <N>          Limit output to N items
+        --json               Output in JSON format
+        --text               Output in human-readable text format (default)
+        --compact            Output in compact single-line format
+```
+
+## Best Practices
+
+### Argument Design
+
+1. **Consistent Naming**: Use consistent argument names across plugins
+   - ✅ `--format`, `--limit`, `--verbose`
+   - ❌ `--fmt`, `--max`, `--verb`
+
+2. **Short Flags**: Provide short versions for common arguments
+   - ✅ `--verbose` / `-v`, `--limit` / `-l`
+   - ❌ Only long forms for frequently used options
+
+3. **Default Values**: Always provide sensible defaults
+   ```rust
+   let limit = matches.get_one::<u32>("limit").unwrap_or(&100);
+   ```
+
+### Parser Selection
+
+**Use Simple Parser (`PluginSettings`) when**:
+- Simple key-value and flag parsing is sufficient
+- Minimal validation requirements
+- Quick prototyping or basic plugins
+
+**Use clap Parser (`PluginArgParser`) when**:
+- Complex argument validation needed
+- Type safety required
+- Professional help text generation
+- Argument conflicts or dependencies
+
+### Configuration Integration
+
+1. **Layer Configuration**: CLI args override TOML config override defaults
+2. **Provide Fallbacks**: Always have working defaults
+3. **Document Config**: Include configuration options in help text
+
+### Error Handling
+
+1. **Clear Messages**: Provide helpful error messages
+2. **Help Integration**: Make help easily accessible
+3. **Graceful Degradation**: Handle partial failures appropriately
+
+## Common Patterns
+
+### Boolean Flag with Configuration
+
+```rust
+let enabled = matches.get_flag("enable") ||
+              config.get_bool("default_enabled", false);
+```
+
+### Numeric Value with Validation
+
+```rust
+let limit = matches.get_one::<u32>("limit")
+    .copied()
+    .or_else(|| config.get_string("default_limit", "100").parse().ok())
+    .unwrap_or(100)
+    .min(1000)  // Clamp maximum
+    .max(1);    // Clamp minimum
+```
+
+### Optional String with Fallback Chain
+
+```rust
+let output_path = matches.get_one::<String>("output")
+    .cloned()
+    .or_else(|| config.get_string("default_output_path", "").into())
+    .filter(|s| !s.is_empty())
+    .unwrap_or_else(|| "/tmp/output".to_string());
+```
+
+## See Also
+
+- [Plugin Functions Documentation](plugin_functions.md)
+- [PluginInfo Documentation](plugin_info.md)
+- [System Architecture Documentation](../system_architecture/plugin_integration.md)
+- [Plugin Author Guide](plugin_author_guide.md)

--- a/docs/plugin_api/index.md
+++ b/docs/plugin_api/index.md
@@ -1,0 +1,489 @@
+# Plugin API Documentation
+
+## Overview
+
+### What is a Plugin?
+
+In the repostats system, a **plugin** is an external component that extends the core functionality of the repository analysis tool. Plugins are dynamically loadable shared libraries (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows) written in Rust that integrate seamlessly with the repostats pipeline.
+
+Plugins operate within a sophisticated data processing pipeline:
+
+```
+Repository → Scanner → Queue → Processing Plugins → Output Plugins → Reports/Exports
+                    ↓
+              Notification System (Events)
+```
+
+### What Can Plugins Be Used For?
+
+Plugins enable extensible repository analysis through various types of functionality:
+
+#### **Processing Plugins** (Real-time Data Processing)
+- **Code Analysis**: Static analysis, complexity metrics, code quality assessment
+- **Pattern Detection**: Security vulnerabilities, coding standards violations, architectural patterns
+- **Data Indexing**: Building searchable indexes of code, commits, or files
+- **Statistics Collection**: Gathering metrics on commits, contributors, file changes
+- **Monitoring**: Tracking of repository activity over time and overall health
+
+#### **Output Plugins** (Report Generation)
+- **Export Formats**: Text, CSV, JSON, XML, Excel, PDF report generation
+- **Visualization**: Charts, graphs, dependency diagrams
+- **Integration**: Pushing data to external systems (databases, APIs, dashboards and graphing tools)
+- **Documentation**: Generating project documentation from code analysis
+- **Compliance**: Regulatory reporting and audit trail generation
+
+#### **Notification Plugins** (Potential Event-Driven Actions)
+- **Alerting**: Email, Slack, webhook notifications for important events
+- **Integration**: Triggering CI/CD pipelines, updating project management tools
+- **Monitoring**: System health checks, performance monitoring
+- **Automation**: Automated responses to repository changes or analysis results
+
+### Plugin Requirements
+
+#### Generic Requirements (All Plugins)
+
+1. **Rust cdylib Library**: Must be compiled as a dynamic library
+2. **API Compatibility**: Must implement the current plugin API version (20250725)
+3. **YAML Manifest**: Must include a `plugin.yaml` file with metadata
+4. **Plugin Trait Implementation**: Must implement the `Plugin` trait
+5. **Thread Safety**: Must be `Send + Sync` for concurrent execution
+6. **Error Handling**: Must use the plugin result system for error reporting
+
+#### Specific Requirements by Type
+
+**Processing Plugins:**
+- Must implement `ConsumerPlugin` trait for queue message processing
+- Should declare `ScanRequires` for selective scanner data needs
+- Must handle `ScanMessage` variants appropriately
+- Should be designed for repository data processing
+
+**Output Plugins:**
+- Should generate final reports or exports
+- May work with processed data from Processing plugins
+- Does not need queue consumers
+- Should support various output formats and integrations
+
+**Notification Plugins:**
+- Should implement event subscribers for system notifications
+- Must handle `Event` types from the notification system
+- May need external service integration
+
+## Table of Contents
+
+### Core API Documentation
+
+#### [PluginInfo Documentation](plugin_info.md)
+**Purpose**: Complete reference for plugin metadata structure
+**Contains**: Field descriptions, validation rules, API version requirements
+**Use When**: Setting up plugin metadata, understanding plugin registration process
+
+#### [ScanRequires Documentation](scan_requires.md)
+**Purpose**: Data requirements system for scanner optimization
+**Contains**: Bitflag system, dependency rules, performance implications
+**Use When**: Declaring what repository data your plugin needs from the scanner
+
+#### [Plugin Functions Documentation](plugin_functions.md)
+**Purpose**: Multi-interface command system for CLI integration
+**Contains**: Function definitions, aliases, command matching
+**Use When**: Implementing CLI commands and function routing in your plugin
+
+#### [CLI Integration Documentation](cli_integration.md)
+**Purpose**: Complete guide to command-line argument processing
+**Contains**: Argument parsing, configuration, segmentation system
+**Use When**: Implementing command-line argument handling and configuration support
+
+#### [System Architecture Documentation](system_architecture.md)
+**Purpose**: Comprehensive system integration guide
+**Contains**: Plugin lifecycle, queue system, scanner integration, notification system
+**Use When**: Understanding how plugins interact with the repostats system
+
+## Creating an External Plugin
+
+### Project Setup
+
+#### 1. Create a New Rust Project
+
+```bash
+# Create a new Rust library project
+cargo new --lib my_analysis_plugin
+cd my_analysis_plugin
+```
+
+#### 2. Configure Cargo.toml
+
+```toml
+[package]
+name = "my_analysis_plugin"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]  # Essential: Creates dynamic library
+
+[dependencies]
+# Core repostats dependencies
+repostats = { path = "../repostats" }  # Adjust path as needed
+async-trait = "0.1"
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+log = "0.4"
+
+# Additional dependencies as needed
+anyhow = "1.0"
+```
+
+#### 3. Create Plugin Manifest (plugin.yaml)
+
+```yaml
+# plugin.yaml - Must be in the same directory as your compiled library
+name: "my-analysis-plugin"
+version: "1.0.0"
+api_version: "20250727"
+description: "Custom repository analysis plugin"
+author: "Your Name <your.email@example.com>"
+license: "MIT"
+
+library:
+  name: "libmy_analysis_plugin"
+  # Platform-specific extensions added automatically:
+  # Linux: libmy_analysis_plugin.so
+  # macOS: libmy_analysis_plugin.dylib
+  # Windows: my_analysis_plugin.dll
+
+commands:
+  - "analyze"
+  - "report"
+  - "export"
+
+dependencies:
+  min_rust_version: "1.80"
+  required_features: ["tokio", "serde"]
+
+metadata:
+  homepage: "https://github.com/yourname/my-analysis-plugin"
+  repository: "https://github.com/yourname/my-analysis-plugin"
+  documentation: "https://docs.rs/my-analysis-plugin"
+```
+
+### Plugin Implementation
+
+#### 4. Basic Plugin Structure (src/lib.rs)
+
+```rust
+use repostats::plugin::traits::{Plugin, ConsumerPlugin};
+use repostats::plugin::types::{PluginInfo, PluginType, PluginFunction};
+use repostats::plugin::args::PluginConfig;
+use repostats::plugin::error::PluginResult;
+use repostats::scanner::types::{ScanRequires, ScanMessage};
+use repostats::queue::api::QueueConsumer;
+use std::collections::HashMap;
+
+/// Your custom analysis plugin
+pub struct MyAnalysisPlugin {
+    initialized: bool,
+    consumer: Option<QueueConsumer>,
+
+    // Plugin-specific state
+    commit_count: u64,
+    file_changes: HashMap<String, u32>,
+
+    // Configuration
+    output_format: String,
+    verbose: bool,
+}
+
+impl MyAnalysisPlugin {
+    pub fn new() -> Self {
+        Self {
+            initialized: false,
+            consumer: None,
+            commit_count: 0,
+            file_changes: HashMap::new(),
+            output_format: "json".to_string(),
+            verbose: false,
+        }
+    }
+
+    async fn process_scan_message(&mut self, message: ScanMessage) -> PluginResult<()> {
+        match message {
+            ScanMessage::RepositoryData { repository_data, .. } => {
+                if self.verbose {
+                    println!("Analyzing repository: {}", repository_data.name);
+                }
+                // Process repository metadata
+            }
+            ScanMessage::CommitData { commit_info, .. } => {
+                self.commit_count += 1;
+                if self.verbose {
+                    println!("Processing commit: {}", commit_info.short_hash);
+                }
+                // Analyze commit data
+            }
+            ScanMessage::FileChange { file_change, .. } => {
+                let counter = self.file_changes.entry(file_change.path.clone()).or_insert(0);
+                *counter += 1;
+                // Track file change patterns
+            }
+            ScanMessage::ScanCompleted { .. } => {
+                // Generate final analysis report
+                self.generate_report().await?;
+            }
+            ScanMessage::ScanError { error_message, .. } => {
+                log::error!("Scanner error: {}", error_message);
+            }
+        }
+        Ok(())
+    }
+
+    async fn generate_report(&self) -> PluginResult<()> {
+        match self.output_format.as_str() {
+            "json" => {
+                let report = serde_json::json!({
+                    "total_commits": self.commit_count,
+                    "files_changed": self.file_changes.len(),
+                    "most_changed_files": self.get_most_changed_files()
+                });
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            }
+            "text" => {
+                println!("=== Analysis Report ===");
+                println!("Total commits: {}", self.commit_count);
+                println!("Files changed: {}", self.file_changes.len());
+                // Add more text output...
+            }
+            _ => {
+                log::warn!("Unsupported output format: {}", self.output_format);
+            }
+        }
+        Ok(())
+    }
+
+    fn get_most_changed_files(&self) -> Vec<(String, u32)> {
+        let mut files: Vec<_> = self.file_changes.iter()
+            .map(|(path, count)| (path.clone(), *count))
+            .collect();
+        files.sort_by(|a, b| b.1.cmp(&a.1));
+        files.into_iter().take(10).collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl Plugin for MyAnalysisPlugin {
+    fn plugin_info(&self) -> PluginInfo {
+        PluginInfo {
+            name: "my-analysis-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            description: "Custom repository analysis plugin".to_string(),
+            author: "Your Name <your.email@example.com>".to_string(),
+            api_version: repostats::get_plugin_api_version(),
+            plugin_type: PluginType::Processing,  // Gets queue consumer
+            functions: vec![
+                PluginFunction {
+                    name: "analyze".to_string(),
+                    description: "Perform repository analysis".to_string(),
+                    aliases: vec!["analyse".to_string(), "scan".to_string()],
+                },
+                PluginFunction {
+                    name: "report".to_string(),
+                    description: "Generate analysis report".to_string(),
+                    aliases: vec!["summary".to_string()],
+                }
+            ],
+            required: (ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO).bits(),
+            auto_active: false,
+        }
+    }
+
+    fn plugin_type(&self) -> PluginType {
+        PluginType::Processing
+    }
+
+    fn advertised_functions(&self) -> Vec<PluginFunction> {
+        vec![
+            PluginFunction {
+                name: "analyze".to_string(),
+                description: "Perform repository analysis".to_string(),
+                aliases: vec!["analyse".to_string(), "scan".to_string()],
+            },
+            PluginFunction {
+                name: "report".to_string(),
+                description: "Generate analysis report".to_string(),
+                aliases: vec!["summary".to_string()],
+            }
+        ]
+    }
+
+    fn requirements(&self) -> ScanRequires {
+        ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO
+    }
+
+    async fn initialize(&mut self) -> PluginResult<()> {
+        println!("Initializing My Analysis Plugin v1.0.0");
+        self.initialized = true;
+        Ok(())
+    }
+
+    async fn execute(&mut self, _args: &[String]) -> PluginResult<()> {
+        if !self.initialized {
+            return Err(repostats::plugin::error::PluginError::ExecutionError {
+                plugin_name: "my-analysis-plugin".to_string(),
+                operation: "execute".to_string(),
+                cause: "Plugin not initialized".to_string(),
+            });
+        }
+        println!("Plugin executed successfully");
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> PluginResult<()> {
+        println!("My Analysis Plugin cleanup completed");
+        Ok(())
+    }
+
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig,
+    ) -> PluginResult<()> {
+        use repostats::plugin::settings::PluginSettings;
+
+        // Parse CLI arguments
+        let settings = PluginSettings::from_cli_args("analyze".to_string(), args.to_vec())?;
+
+        // Apply configuration
+        self.output_format = settings.get_arg("format")
+            .cloned()
+            .unwrap_or_else(|| config.get_string("output_format", "json"));
+
+        self.verbose = settings.has_flag("verbose") || config.get_bool("verbose", false);
+
+        if self.verbose {
+            println!("Plugin configured: format={}, verbose={}", self.output_format, self.verbose);
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsumerPlugin for MyAnalysisPlugin {
+    async fn start_consuming(&mut self, consumer: QueueConsumer) -> PluginResult<()> {
+        println!("Starting message consumption...");
+        self.consumer = Some(consumer.clone());
+
+        // Clone necessary data for the async task
+        let verbose = self.verbose;
+
+        // Spawn background task for message processing
+        tokio::spawn(async move {
+            loop {
+                match consumer.receive_message().await {
+                    Ok(message) => {
+                        // Process message (this is simplified - in reality you'd need
+                        // to pass the message back to the plugin instance)
+                        if verbose {
+                            println!("Received message: {:?}", message.message_type());
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to receive message: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop_consuming(&mut self) -> PluginResult<()> {
+        if let Some(consumer) = &self.consumer {
+            consumer.close().await?;
+        }
+        self.consumer = None;
+        println!("Stopped consuming messages");
+        Ok(())
+    }
+}
+
+/// Factory function required for dynamic loading
+#[no_mangle]
+pub extern "C" fn create_plugin() -> *mut dyn Plugin {
+    Box::into_raw(Box::new(MyAnalysisPlugin::new()))
+}
+
+/// Plugin API version check - required for compatibility
+#[no_mangle]
+pub extern "C" fn plugin_api_version() -> u32 {
+    20250101
+}
+```
+
+### Building and Installation
+
+#### 5. Build the Plugin
+
+```bash
+# Build the plugin as a release binary
+cargo build --release
+
+# The compiled library will be in target/release/
+# Linux: libmy_analysis_plugin.so
+# macOS: libmy_analysis_plugin.dylib
+# Windows: my_analysis_plugin.dll
+```
+
+#### 6. Install the Plugin
+
+```bash
+# Create plugin directory structure
+mkdir -p ~/.local/share/repostats/plugins/my-analysis-plugin
+
+# Copy the compiled library and manifest
+cp target/release/libmy_analysis_plugin.so ~/.local/share/repostats/plugins/my-analysis-plugin/
+cp plugin.yaml ~/.local/share/repostats/plugins/my-analysis-plugin/
+
+# The plugin should now be discoverable by repostats
+repostats --plugins  # List available plugins
+```
+
+#### 7. Using the Plugin
+
+```bash
+# Use the plugin with CLI commands
+repostats --config myconfig.toml analyze --format json --verbose
+
+# The plugin will:
+# 1. Be discovered via its manifest
+# 2. Loaded as a dynamic library
+# 3. Activated based on the "analyze" command
+# 4. Process repository scan messages
+# 5. Generate the final analysis report
+```
+
+### Development Tips
+
+1. **Testing**: Create unit tests for your plugin logic, integration tests for the plugin interface
+2. **Logging**: Use the `log` crate for proper logging integration
+3. **Error Handling**: Always use `PluginResult` for error returns
+4. **Performance**: Consider memory usage when processing large repositories
+5. **Configuration**: Support both CLI arguments and TOML configuration files
+6. **Documentation**: Document your plugin's functions, arguments, and configuration options
+
+### Troubleshooting
+
+- **Plugin Not Found**: Check that `plugin.yaml` exists alongside the compiled library
+- **API Version Mismatch**: Ensure your plugin's API version matches the repostats version
+- **Loading Errors**: Verify that all dependencies are available and the library is correctly compiled
+- **Runtime Errors**: Check logs for detailed error messages and stack traces
+
+## Next Steps
+
+After reading this overview, explore the detailed documentation for specific aspects of plugin development:
+
+1. Start with [System Architecture](system_architecture.md) to understand the overall system
+2. Review [Plugin Functions](plugin_functions.md) to implement CLI commands
+3. Study [CLI Integration](cli_integration.md) for argument processing
+4. Reference [PluginInfo](plugin_info.md) and [ScanRequires](scan_requires.md) for API details
+
+For questions or contributions, refer to the main repostats project documentation and issue tracker.

--- a/docs/plugin_api/plugin_functions.md
+++ b/docs/plugin_api/plugin_functions.md
@@ -1,0 +1,339 @@
+# Plugin Functions Documentation
+
+## Overview
+
+The `PluginFunction` system enables plugins to provide multiple command line interfaces and aliases for their functionality. This system bridges the gap between CLI command parsing and plugin activation, allowing users to invoke plugins through various command names and arguments.
+
+## Structure
+
+```rust
+pub struct PluginFunction {
+    pub name: String,        // Primary function name
+    pub description: String, // Function description
+    pub aliases: Vec<String>, // Alternative names
+}
+```
+
+## Core Concepts
+
+### Function Registration
+
+Plugins declare their available functions through the `advertised_functions()` trait method:
+
+```rust
+impl Plugin for MyPlugin {
+    fn advertised_functions(&self) -> Vec<PluginFunction> {
+        vec![
+            PluginFunction {
+                name: "analyse".to_string(),
+                description: "Analyse repository statistics".to_string(),
+                aliases: vec!["analyze".to_string(), "stats".to_string()],
+            },
+            PluginFunction {
+                name: "export".to_string(),
+                description: "Export data in various formats".to_string(),
+                aliases: vec!["dump".to_string(), "output".to_string()],
+            }
+        ]
+    }
+}
+```
+
+### Command Line Integration
+
+The function system integrates with CLI parsing through a two-stage process:
+
+#### Stage 1: Command Segmentation
+
+The `CommandSegmenter` splits CLI arguments into discrete command segments:
+
+```bash
+repostats --verbose analyse --since 1week export --format json
+```
+
+Becomes:
+- Global args: `["repostats", "--verbose"]`
+- Command segments:
+  - `CommandSegment { command_name: "analyse", args: ["--since", "1week"] }`
+  - `CommandSegment { command_name: "export", args: ["--format", "json"] }`
+
+#### Stage 2: Function Matching
+
+The plugin manager matches command segments against plugin functions:
+
+1. **Primary Name Matching**: `function.name == segment.command_name`
+2. **Alias Matching**: `function.aliases.contains(&segment.command_name)`
+3. **Activation**: Creates `ActivePluginInfo` when matched
+
+```rust
+// Example matching logic
+if function.name == segment.command_name || function.aliases.contains(&segment.command_name) {
+    self.active_plugins.push(ActivePluginInfo {
+        plugin_name: plugin_name.clone(),
+        function_name: function.name.clone(),  // Always uses primary name
+        args: segment.args.clone(),           // Command-specific arguments
+    });
+}
+```
+
+## Function Properties
+
+### `name: String`
+**Purpose**: Primary identifier for the function within the plugin.
+
+**Requirements**:
+- Must be non-empty
+- Must not contain control characters
+- Should be unique within the plugin
+- Used as the canonical function identifier in `ActivePluginInfo`
+
+**Usage**:
+- Primary CLI command name
+- Function identifier in activation records
+- Default command name when no aliases match
+
+**Example**: `"analyse"`, `"export"`, `"generate"`
+
+### `description: String`
+**Purpose**: Human-readable description of function capabilities.
+
+**Requirements**:
+- Should clearly explain what the function does
+- Used in help text and plugin listings
+- Must not contain control characters except spaces
+
+**Usage**:
+- CLI help documentation
+- Plugin function discovery
+- User interface displays
+
+**Example**: `"Analyse repository commit patterns and generate statistics"`
+
+### `aliases: Vec<String>`
+**Purpose**: Alternative command names that invoke the same function.
+
+**Requirements**:
+- Each alias must be unique across all plugin functions
+- Should be intuitive synonyms or shorter versions
+- Used for user convenience and command compatibility
+
+**Usage**:
+- Command line shortcuts
+- Alternative spellings (e.g., "analyse"/"analyze")
+- Legacy command compatibility
+
+**Benefits**:
+- **User Convenience**: Multiple ways to invoke same functionality
+- **Internationalisation**: Support different spelling conventions
+- **Backwards Compatibility**: Maintain old command names during refactoring
+
+**Example**: `vec!["analyze".to_string(), "stats".to_string(), "report".to_string()]`
+
+## Active Plugin Information
+
+When a function is matched, the system creates an `ActivePluginInfo` record:
+
+```rust
+pub struct ActivePluginInfo {
+    pub plugin_name: String,   // Name of the matched plugin
+    pub function_name: String, // Primary function name (never alias)
+    pub args: Vec<String>,     // Arguments from command segment
+}
+```
+
+### Key Behaviours
+
+1. **Canonical Function Names**: `function_name` always contains the primary name, never an alias
+2. **Argument Preservation**: Command arguments are preserved exactly as provided
+3. **Plugin Identification**: Links function activation back to source plugin
+
+## Multiple Function Plugins
+
+Plugins can advertise multiple functions for different capabilities:
+
+```rust
+fn advertised_functions(&self) -> Vec<PluginFunction> {
+    vec![
+        PluginFunction {
+            name: "start".to_string(),
+            description: "Start monitoring repository changes".to_string(),
+            aliases: vec!["begin".to_string(), "run".to_string()],
+        },
+        PluginFunction {
+            name: "stop".to_string(),
+            description: "Stop monitoring and generate report".to_string(),
+            aliases: vec!["end".to_string(), "finish".to_string()],
+        },
+        PluginFunction {
+            name: "status".to_string(),
+            description: "Show current monitoring status".to_string(),
+            aliases: vec!["info".to_string()],
+        }
+    ]
+}
+```
+
+### CLI Usage Examples
+
+```bash
+# Using primary names
+repostats start --interval 5m
+repostats stop --save results.json
+repostats status
+
+# Using aliases
+repostats run --interval 5m      # Equivalent to 'start'
+repostats finish --save data.json # Equivalent to 'stop'
+repostats info                    # Equivalent to 'status'
+```
+
+## Function Discovery Process
+
+The plugin manager discovers functions through these steps:
+
+1. **Plugin Discovery**: Find all available plugins
+2. **Function Collection**: Call `advertised_functions()` on each plugin
+3. **Command Registration**: Register all function names and aliases with `CommandSegmenter`
+4. **Activation Matching**: Match CLI commands against registered functions during runtime
+
+### Discovery Code Flow
+
+```rust
+// Collect all plugin functions
+let mut plugin_functions = Vec::new();
+for plugin_name in plugin_names {
+    if let Some(plugin) = registry.get_plugin(&plugin_name) {
+        let functions = plugin.advertised_functions();
+        plugin_functions.push((plugin_name, functions));
+    }
+}
+
+// Build command list for segmenter
+let mut known_commands = Vec::new();
+for (_, functions) in &plugin_functions {
+    for function in functions {
+        known_commands.push(function.name.clone());
+        known_commands.extend(function.aliases.clone());
+    }
+}
+```
+
+## Best Practices
+
+### Naming Conventions
+
+1. **Primary Names**: Use clear, descriptive verbs
+   - ✅ `"analyse"`, `"generate"`, `"export"`
+   - ❌ `"do"`, `"thing"`, `"run"`
+
+2. **Aliases**: Provide common variants and shortcuts
+   - ✅ `["analyze", "stats", "report"]` for `"analyse"`
+   - ❌ `["a", "x", "z"]` (unclear abbreviations)
+
+3. **Consistency**: Maintain consistent naming across functions
+   - ✅ `"start"`/`"stop"` pair
+   - ❌ `"begin"`/`"terminate"` (inconsistent style)
+
+### Function Design
+
+1. **Single Responsibility**: Each function should have a clear, distinct purpose
+2. **Logical Grouping**: Related functions should be in the same plugin
+3. **User Experience**: Consider how users will discover and use functions
+
+### Argument Handling
+
+Plugins receive raw command arguments and should:
+
+1. **Validate Arguments**: Check argument count and format
+2. **Provide Help**: Handle `--help` or invalid arguments gracefully
+3. **Error Reporting**: Return clear error messages for invalid usage
+
+## Integration Examples
+
+### Simple Single-Function Plugin
+
+```rust
+impl Plugin for DumpPlugin {
+    fn advertised_functions(&self) -> Vec<PluginFunction> {
+        vec![PluginFunction {
+            name: "dump".to_string(),
+            description: "Dump repository data for debugging".to_string(),
+            aliases: vec!["debug".to_string(), "trace".to_string()],
+        }]
+    }
+
+    async fn execute_function(&self, function_name: &str, args: &[String]) -> Result<()> {
+        match function_name {
+            "dump" => self.handle_dump(args).await,
+            _ => Err(anyhow::anyhow!("Unknown function: {}", function_name)),
+        }
+    }
+}
+```
+
+### Multi-Function Plugin with Routing
+
+```rust
+impl Plugin for StatisticsPlugin {
+    fn advertised_functions(&self) -> Vec<PluginFunction> {
+        vec![
+            PluginFunction {
+                name: "summary".to_string(),
+                description: "Generate statistical summary".to_string(),
+                aliases: vec!["stats".to_string()],
+            },
+            PluginFunction {
+                name: "detailed".to_string(),
+                description: "Generate detailed statistics report".to_string(),
+                aliases: vec!["detail".to_string(), "full".to_string()],
+            }
+        ]
+    }
+
+    async fn execute_function(&self, function_name: &str, args: &[String]) -> Result<()> {
+        match function_name {
+            "summary" => self.generate_summary(args).await,
+            "detailed" => self.generate_detailed(args).await,
+            _ => Err(anyhow::anyhow!("Unknown function: {}", function_name)),
+        }
+    }
+}
+```
+
+## Error Handling
+
+### Function Not Found
+
+When no plugin function matches a command segment:
+
+```rust
+warn!("PluginManager: No plugin found for command '{}'", segment.command_name);
+return Err(PluginError::PluginNotFound {
+    plugin_name: segment.command_name.clone(),
+});
+```
+
+### Function Execution Errors
+
+Plugins should handle function execution errors appropriately:
+
+```rust
+async fn execute_function(&self, function_name: &str, args: &[String]) -> Result<()> {
+    match function_name {
+        "analyse" => {
+            if args.is_empty() {
+                return Err(anyhow::anyhow!("analyse function requires arguments"));
+            }
+            self.perform_analysis(args).await
+        },
+        _ => Err(anyhow::anyhow!("Unsupported function: {}", function_name)),
+    }
+}
+```
+
+## See Also
+
+- [PluginInfo Documentation](plugin_info.md)
+- [ScanRequires Documentation](scan_requires.md)
+- [Command Line Integration Guide](../system_architecture/cli_integration.md)
+- [Plugin Author Guide](plugin_author_guide.md)

--- a/docs/plugin_api/plugin_info.md
+++ b/docs/plugin_api/plugin_info.md
@@ -1,0 +1,207 @@
+# PluginInfo Documentation
+
+## Overview
+
+The `PluginInfo` struct is the central metadata container for all plugins in the repostats system. It provides comprehensive information about a plugin's capabilities, requirements, and interface to the plugin manager.
+
+## Structure
+
+```rust
+pub struct PluginInfo {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub author: String,
+    pub api_version: u32,
+    pub plugin_type: PluginType,
+    pub functions: Vec<PluginFunction>,
+    pub required: u64,
+    pub auto_active: bool,
+}
+```
+
+## Field Descriptions
+
+### `name: String`
+**Purpose**: Unique identifier for the plugin within the system.
+
+**Requirements**:
+- Must be non-empty
+- Must not contain control characters or tabs
+- Used for plugin discovery and activation
+- Must be unique across all plugins
+
+**Example**: `"dump"`, `"statistics"`, `"export"`
+
+### `version: String`
+**Purpose**: Semantic version of the plugin implementation.
+
+**Requirements**:
+- Should follow semantic versioning (e.g., "1.0.0")
+- Used for compatibility checking
+- Displayed in plugin listings
+
+**Example**: `"1.0.0"`, `"2.1.3-beta"`
+
+### `description: String`
+**Purpose**: Human-readable description of plugin functionality.
+
+**Requirements**:
+- Must not contain control characters (except spaces)
+- Should be concise but informative
+- Displayed in plugin help and listings
+
+**Example**: `"Dump repository data for debugging purposes"`
+
+### `author: String`
+**Purpose**: Plugin author or maintainer identification.
+
+**Requirements**:
+- Can be individual name, organization, or email
+- Used for plugin attribution
+- Displayed in plugin information
+
+**Example**: `"RepoStats"`, `"Jane Smith <jane@example.com>"`
+
+### `api_version: u32`
+**Purpose**: API version compatibility indicator.
+
+**Requirements**:
+- Must match system API version for plugin to load
+- Used for forward/backward compatibility checks
+- Current API version: `20250101`
+
+**Example**: `20250101`
+
+### `plugin_type: PluginType`
+**Purpose**: Defines functional category and queue interaction behavior.
+
+**Available Types**:
+- `PluginType::Processing` - Actively processes queue messages, gets queue subscribers
+- `PluginType::Output` - Generates reports/exports, no queue subscribers
+- `PluginType::Notification` - Event-driven, no queue subscribers
+
+**Queue Subscriber Rules**:
+- **Processing plugins**: Always get queue subscribers for message processing
+- **Output plugins**: Do not get queue subscribers
+- **Notification plugins**: Do not get queue subscribers
+
+**Example**: `PluginType::Processing`
+
+### `functions: Vec<PluginFunction>`
+**Purpose**: List of functions/commands that this plugin provides.
+
+**Structure**:
+```rust
+pub struct PluginFunction {
+    pub name: String,        // Primary function name
+    pub description: String, // Function description
+    pub aliases: Vec<String>, // Alternative names
+}
+```
+
+**Requirements**:
+- At least one function should be provided for non-auto-active plugins
+- Function names must not contain control characters
+- Used for CLI command matching and plugin discovery
+
+**Example**:
+```rust
+vec![PluginFunction {
+    name: "dump".to_string(),
+    description: "Start dumping messages to stdout".to_string(),
+    aliases: vec!["start".to_string(), "run".to_string()],
+}]
+```
+
+### `required: u64`
+**Purpose**: Bitflags indicating what data the plugin requires from the scanner.
+
+**Value Source**: `ScanRequires::bits()` - bitflag representation of requirements
+
+**Available Requirements**:
+- `ScanRequires::NONE` (0) - No special requirements
+- `ScanRequires::REPOSITORY_INFO` - Repository metadata
+- `ScanRequires::HISTORY` - Commit history information
+- `ScanRequires::FILE_CHANGES` - File change details
+- Combined: `(ScanRequires::REPOSITORY_INFO | ScanRequires::HISTORY).bits()`
+
+**Usage**: Scanner uses this to optimize message generation - only produces messages that active plugins need.
+
+**Example**: `(ScanRequires::REPOSITORY_INFO | ScanRequires::HISTORY | ScanRequires::FILE_CHANGES).bits()`
+
+### `auto_active: bool`
+**Purpose**: Whether plugin should be automatically activated during discovery.
+
+**Behavior**:
+- `true`: Plugin is activated immediately when discovered, without CLI command
+- `false`: Plugin only activated when explicitly requested via CLI command
+
+**Use Cases**:
+- Background monitoring plugins
+- System health checkers
+- Automatic data collection plugins
+
+**Default**: `false` (most plugins should be explicitly activated)
+
+## Implementation Example
+
+```rust
+fn plugin_info(&self) -> PluginInfo {
+    PluginInfo {
+        name: "example".to_string(),
+        version: "1.0.0".to_string(),
+        description: "Example plugin for demonstration".to_string(),
+        author: "Plugin Developer".to_string(),
+        api_version: 20250101,
+        plugin_type: PluginType::Processing,
+        functions: vec![
+            PluginFunction {
+                name: "process".to_string(),
+                description: "Process repository data".to_string(),
+                aliases: vec!["proc".to_string(), "run".to_string()],
+            }
+        ],
+        required: (ScanRequires::REPOSITORY_INFO | ScanRequires::FILE_CHANGES).bits(),
+        auto_active: false,
+    }
+}
+```
+
+## Validation Rules
+
+The system validates `PluginInfo` during plugin registration:
+
+1. **Name validation**: Non-empty, no control characters
+2. **Description validation**: No control characters except spaces
+3. **Function validation**: All function names free of control characters
+4. **API compatibility**: `api_version` must match system version
+5. **Type consistency**: `plugin_type` determines queue subscriber allocation
+
+## Integration with Plugin Traits
+
+`PluginInfo` should be consistent with plugin trait method implementations:
+
+```rust
+impl Plugin for MyPlugin {
+    fn plugin_info(&self) -> PluginInfo {
+        PluginInfo {
+            // ... other fields ...
+            plugin_type: self.plugin_type(),           // Should match
+            functions: self.advertised_functions(),     // Should match
+            required: self.requirements().bits(),      // Should match
+            // ...
+        }
+    }
+
+    fn plugin_type(&self) -> PluginType { /* ... */ }
+    fn advertised_functions(&self) -> Vec<PluginFunction> { /* ... */ }
+    fn requirements(&self) -> ScanRequires { /* ... */ }
+}
+```
+
+## See Also
+
+- [ScanRequires Documentation](scan_requires.md)
+- [Plugin Functions Documentation](plugin_functions.md)
+- [Plugin Author Guide](plugin_author_guide.md)

--- a/docs/plugin_api/scan_requires.md
+++ b/docs/plugin_api/scan_requires.md
@@ -1,0 +1,255 @@
+# ScanRequires Documentation
+
+## Overview
+
+`ScanRequires` is a bitflag system that allows plugins to declare what data they need from the scanner. The scanner uses these requirements to optimize message generation and only produces the data that active plugins actually need.
+
+## Structure
+
+`ScanRequires` is implemented as a wrapper around `u64` with bitflag operations:
+
+```rust
+pub struct ScanRequires(u64);
+```
+
+## Available Requirements
+
+### `ScanRequires::NONE`
+**Value**: `0`
+**Purpose**: Plugin requires no specific data from scanner
+**Usage**: Default for plugins that work with minimal data
+
+### `ScanRequires::REPOSITORY_INFO`
+**Value**: `1 << 0` (bit 0)
+**Purpose**: Repository metadata (name, path, branch, etc.)
+**Dependencies**: None
+**Use Cases**: Plugins that need basic repository information
+
+### `ScanRequires::COMMITS`
+**Value**: `1 << 1` (bit 1)
+**Purpose**: Individual commit information
+**Dependencies**: None
+**Use Cases**: Plugins analyzing commit patterns, authors, timestamps
+
+### `ScanRequires::FILE_CHANGES`
+**Value**: `1 << 2 | COMMITS` (bit 2 + dependencies)
+**Purpose**: Detailed file change information for each commit
+**Dependencies**: Automatically includes `COMMITS`
+**Use Cases**: Plugins analyzing code changes, file modifications
+
+### `ScanRequires::FILE_CONTENT`
+**Value**: `1 << 3 | FILE_CHANGES` (bit 3 + dependencies)
+**Purpose**: Actual file content at HEAD/tag/commit
+**Dependencies**: Automatically includes `FILE_CHANGES` and `COMMITS`
+**Use Cases**: Static analysis, code quality checking, content processing
+
+### `ScanRequires::HISTORY`
+**Value**: `1 << 4 | COMMITS` (bit 4 + dependencies)
+**Purpose**: Full commit history traversal
+**Dependencies**: Automatically includes `COMMITS`
+**Use Cases**: Historical analysis, trend detection, long-term statistics
+
+## Dependency Rules
+
+Requirements automatically include their dependencies:
+
+```
+FILE_CONTENT
+    └── FILE_CHANGES
+        └── COMMITS
+
+HISTORY
+    └── COMMITS
+
+REPOSITORY_INFO (independent)
+```
+
+**Important**: You only need to specify the highest-level requirement you need. Dependencies are automatically included.
+
+## Additive Behavior
+
+The plugin system uses **additive requirements aggregation**:
+
+- If ANY active plugin needs a requirement, ALL active plugins receive those messages
+- Individual plugins do NOT get filtered message streams
+- Plugins must filter messages themselves if they're not interested
+- This prevents complex per-plugin message routing
+
+**Example**: If Plugin A needs `COMMITS` and Plugin B needs `FILE_CHANGES`, both plugins will receive `FILE_CHANGES` messages (which include `COMMITS`).
+
+## API Methods
+
+### Construction and Conversion
+```rust
+ScanRequires::NONE                    // No requirements
+ScanRequires::from_bits(42)          // From raw bits
+requirements.bits()                   // To raw bits (for PluginInfo.required)
+```
+
+### Combining Requirements
+```rust
+let combined = ScanRequires::REPOSITORY_INFO | ScanRequires::FILE_CHANGES;
+let mut reqs = ScanRequires::COMMITS;
+reqs |= ScanRequires::HISTORY;       // Add more requirements
+```
+
+### Checking Requirements
+```rust
+requirements.is_empty()                           // No requirements set
+requirements.contains(ScanRequires::COMMITS)     // Has specific requirement
+requirements.requires_repository_info()          // Convenience methods
+requirements.requires_commits()
+requirements.requires_file_changes()
+requirements.requires_file_content()
+requirements.requires_history()
+```
+
+### Set Operations
+```rust
+let union = req1.union(req2);              // Combine (OR)
+let intersection = req1.intersection(req2); // Common (AND)
+let difference = req1.difference(req2);     // Remove
+```
+
+## Usage in Plugins
+
+### Plugin Trait Implementation
+```rust
+impl Plugin for MyPlugin {
+    fn requirements(&self) -> ScanRequires {
+        // Specify the highest level you need - dependencies included automatically
+        ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO
+    }
+}
+```
+
+### PluginInfo Integration
+```rust
+fn plugin_info(&self) -> PluginInfo {
+    PluginInfo {
+        // Convert to bits for storage
+        required: self.requirements().bits(),
+        // ... other fields
+    }
+}
+```
+
+## Common Patterns
+
+### Basic Repository Analysis
+```rust
+// Only need repository metadata
+ScanRequires::REPOSITORY_INFO
+```
+
+### Commit Statistics
+```rust
+// Need commit information but not file details
+ScanRequires::COMMITS
+```
+
+### Code Change Analysis
+```rust
+// Need file changes (automatically includes commits)
+ScanRequires::FILE_CHANGES
+```
+
+### Static Code Analysis
+```rust
+// Need actual file content (includes file changes and commits)
+ScanRequires::FILE_CONTENT
+```
+
+### Historical Trend Analysis
+```rust
+// Need full history traversal and repository info
+ScanRequires::HISTORY | ScanRequires::REPOSITORY_INFO
+```
+
+### Comprehensive Analysis
+```rust
+// Need everything
+ScanRequires::FILE_CONTENT | ScanRequires::HISTORY | ScanRequires::REPOSITORY_INFO
+```
+
+## Performance Considerations
+
+### Scanner Optimization
+- Scanner only generates messages for required data types
+- Unused message types are completely skipped
+- Significant performance improvement when plugins need minimal data
+
+### Memory Usage
+- File content requirements can use substantial memory for large repositories
+- History traversal can be time-intensive for repositories with many commits
+- Consider whether your plugin truly needs high-level requirements
+
+### Dependency Inclusion
+- Requesting `FILE_CONTENT` automatically includes `FILE_CHANGES` and `COMMITS`
+- Don't specify dependencies explicitly - they're included automatically
+- Specifying lower-level dependencies redundantly doesn't hurt but isn't necessary
+
+## Examples
+
+### Example 1: Statistics Plugin
+```rust
+impl Plugin for StatisticsPlugin {
+    fn requirements(&self) -> ScanRequires {
+        // Need commit info and repository metadata for statistics
+        ScanRequires::COMMITS | ScanRequires::REPOSITORY_INFO
+    }
+}
+```
+
+### Example 2: Code Quality Plugin
+```rust
+impl Plugin for CodeQualityPlugin {
+    fn requirements(&self) -> ScanRequires {
+        // Need actual file content for static analysis
+        // This automatically includes FILE_CHANGES and COMMITS
+        ScanRequires::FILE_CONTENT
+    }
+}
+```
+
+### Example 3: History Analyzer Plugin
+```rust
+impl Plugin for HistoryAnalyzerPlugin {
+    fn requirements(&self) -> ScanRequires {
+        // Need full history and repository info
+        // HISTORY automatically includes COMMITS
+        ScanRequires::HISTORY | ScanRequires::REPOSITORY_INFO
+    }
+}
+```
+
+## Display Format
+
+`ScanRequires` implements `Display` for human-readable output:
+
+```rust
+println!("{}", requirements);
+// Output examples:
+// "None"
+// "RepositoryInfo"
+// "RepositoryInfo, FileChanges"
+// "RepositoryInfo, FileContent, History"
+```
+
+## Integration with Scanner
+
+The plugin manager collects requirements from all active plugins and passes the combined requirements to the scanner:
+
+```rust
+// Plugin manager aggregates requirements
+let combined_requirements = plugin_manager.get_combined_requirements();
+
+// Scanner uses requirements to optimize message generation
+scanner.set_requirements(combined_requirements);
+```
+
+## See Also
+
+- [PluginInfo Documentation](plugin_info.md)
+- [Plugin Functions Documentation](plugin_functions.md)
+- [Scanner Integration Documentation](../system_architecture/scanner_integration.md)

--- a/docs/plugin_api/system_architecture.md
+++ b/docs/plugin_api/system_architecture.md
@@ -1,0 +1,881 @@
+# System Architecture Documentation for Plugin Authors
+
+## Overview
+
+The repostats system provides a sophisticated plugin architecture built around four core components: **Plugin Manager**, **Queue System**, **Scanner Integration**, and **Notification System**. Understanding how these components work together is essential for plugin authors to build effective and well-integrated plugins.
+
+## Architecture Overview
+
+### Data Flow
+
+```
+Repository → Scanner → Queue → Analysis Plugins → Output Plugins → Reports
+                    ↓
+              Notification System (Events for all components)
+```
+
+### Core Components
+
+1. **Plugin Manager**: Discovers, registers, and manages plugin lifecycle
+2. **Queue System**: Provides message-passing infrastructure between scanner and plugins
+3. **Scanner Integration**: Generates repository data based on plugin requirements
+4. **Notification System**: Provides event-driven communication across the system
+
+## Plugin Manager
+
+The Plugin Manager serves as the central orchestrator for all plugin operations, handling discovery, activation, and lifecycle management.
+
+### Plugin Lifecycle
+
+#### 1. Discovery Phase
+
+The Plugin Manager discovers plugins through multiple sources:
+
+```rust
+// Built-in plugins (compiled into the application)
+registry.register_builtin_plugin("dump", || Box::new(DumpPlugin::new()));
+
+// External plugins (shared libraries)
+// Discovery happens in configured plugin directories
+```
+
+#### 2. Registration Phase
+
+During registration, plugins provide metadata through `PluginInfo`:
+
+```rust
+fn plugin_info(&self) -> PluginInfo {
+    PluginInfo {
+        name: "example".to_string(),
+        version: "1.0.0".to_string(),
+        description: "Example analysis plugin".to_string(),
+        author: "Plugin Author".to_string(),
+        api_version: 20250101,
+        plugin_type: PluginType::Processing,  // Determines queue access
+        functions: vec![/* CLI functions */],
+        required: ScanRequires::FILE_CHANGES.bits(),  // Scanner requirements
+        auto_active: false,  // Manual activation required
+    }
+}
+```
+
+#### 3. Activation Phase
+
+Plugins are activated in two ways:
+
+**Manual Activation** (via CLI commands):
+```bash
+repostats analyse --since 1week
+# Activates plugin with "analyse" function, args: ["--since", "1week"]
+```
+
+**Auto Activation** (during discovery):
+```rust
+PluginInfo {
+    auto_active: true,  // Plugin activates automatically
+    // ...
+}
+```
+
+#### 4. Initialization Phase
+
+Once activated, plugins go through initialization:
+
+```rust
+impl Plugin for MyPlugin {
+    async fn initialize(&mut self) -> PluginResult<()> {
+        // Set up internal state
+        // Validate configuration
+        // Prepare for execution
+        Ok(())
+    }
+
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig,
+    ) -> PluginResult<()> {
+        // Parse CLI arguments
+        // Apply TOML configuration
+        // Validate arguments
+        Ok(())
+    }
+}
+```
+
+### Plugin Types and Queue Access
+
+Plugin type determines queue subscriber allocation:
+
+```rust
+pub enum PluginType {
+    Processing,     // Gets QueueConsumer - processes messages real-time
+    Output,         // No QueueConsumer - works with processed data
+    Notification,   // No QueueConsumer - responds to events only
+}
+```
+
+**Processing Plugins** (with QueueConsumer):
+- Receive scan messages in real-time
+- Process, transform, or analyze data
+- Examples: indexers, pattern detectors, statistics calculators
+
+**Output Plugins** (no QueueConsumer):
+- Generate final reports or exports
+- Work with data from Processing plugins
+- Examples: CSV exporters, report generators
+
+**Notification Plugins** (no QueueConsumer):
+- Respond to system events
+- Handle monitoring and alerting
+- Examples: webhook notifiers, health monitors
+
+### Plugin Configuration
+
+Plugins receive configuration through two channels:
+
+#### CLI Arguments
+```rust
+async fn parse_plugin_arguments(
+    &mut self,
+    args: &[String],           // ["--format", "json", "--verbose"]
+    config: &PluginConfig,
+) -> PluginResult<()> {
+    // Parse using PluginSettings (simple) or PluginArgParser (clap)
+}
+```
+
+#### TOML Configuration
+```toml
+# repostats.toml
+[my_plugin]
+default_format = "json"
+max_entries = 1000
+verbose = true
+```
+
+```rust
+// In plugin
+let format = config.get_string("default_format", "text");
+let max_entries = config.get_string("max_entries", "100")
+    .parse::<usize>()
+    .unwrap_or(100);
+let verbose = config.get_bool("verbose", false);
+```
+
+## Queue System
+
+The Queue System provides a single global message queue that all producers (scanners) publish to and all consumers (plugins) read from.
+
+### Queue Architecture
+
+```
+Scanner(s) → Global Queue → Plugin Consumer 1
+                        → Plugin Consumer 2
+                        → Plugin Consumer N
+```
+
+### Message Consumption for Processing Plugins
+
+Processing plugins automatically receive a `QueueConsumer` and implement the `ConsumerPlugin` trait:
+
+```rust
+#[async_trait::async_trait]
+impl ConsumerPlugin for MyPlugin {
+    async fn start_consuming(&mut self, consumer: QueueConsumer) -> PluginResult<()> {
+        // Store the consumer
+        self.consumer = Some(consumer);
+
+        // Spawn background task for message processing
+        let consumer_clone = self.consumer.as_ref().unwrap().clone();
+        tokio::spawn(async move {
+            loop {
+                match consumer_clone.receive_message().await {
+                    Ok(message) => {
+                        // Process the message
+                        self.process_scan_message(message).await?;
+                    }
+                    Err(e) => {
+                        log::error!("Failed to receive message: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop_consuming(&mut self) -> PluginResult<()> {
+        // Clean shutdown of consumer
+        if let Some(consumer) = &self.consumer {
+            consumer.close().await?;
+        }
+        self.consumer = None;
+        Ok(())
+    }
+}
+```
+
+### Message Processing
+
+Plugins receive `ScanMessage` enum variants based on their requirements:
+
+```rust
+use crate::scanner::types::ScanMessage;
+
+async fn process_scan_message(&mut self, message: ScanMessage) -> PluginResult<()> {
+    match message {
+        ScanMessage::RepositoryData { scanner_id, timestamp, repository_data } => {
+            // Process repository metadata
+            println!("Repository: {} at {}", repository_data.name, repository_data.path);
+        }
+        ScanMessage::CommitData { scanner_id, timestamp, commit_info } => {
+            // Process individual commits
+            println!("Commit: {} by {}", commit_info.hash, commit_info.author_name);
+        }
+        ScanMessage::FileChange { scanner_id, timestamp, file_change } => {
+            // Process file changes within commits
+            println!("File changed: {} ({})", file_change.path, file_change.change_type);
+        }
+        ScanMessage::ScanCompleted { scanner_id, timestamp } => {
+            // Scanner finished - finalize processing
+            self.finalize_analysis().await?;
+        }
+        ScanMessage::ScanError { scanner_id, timestamp, error_message } => {
+            // Handle scanner errors
+            log::error!("Scanner error: {}", error_message);
+        }
+    }
+    Ok(())
+}
+```
+
+### Queue Consumer Management
+
+The Plugin Manager handles consumer lifecycle:
+
+1. **Creation**: Consumers created during plugin activation for Processing plugins
+2. **Activation**: Consumers activated after plugin initialization
+3. **Management**: Plugin Manager monitors consumer health and lag
+4. **Cleanup**: Consumers cleaned up during plugin shutdown
+
+```rust
+// Plugin Manager creates consumers for Processing plugins
+if plugin_type == PluginType::Processing {
+    let consumer = queue_manager.create_consumer(plugin_name.clone())?;
+    pending_consumers.insert(plugin_name, consumer);
+}
+
+// Later activation
+for (plugin_name, consumer) in pending_consumers.drain() {
+    if let Some(plugin) = registry.get_consumer_plugin_mut(&plugin_name) {
+        plugin.start_consuming(consumer).await?;
+    }
+}
+```
+
+### Message Types and Content
+
+Messages contain different data based on scanner requirements:
+
+#### RepositoryData Message
+```rust
+ScanMessage::RepositoryData {
+    scanner_id,     // Unique scanner identifier
+    timestamp,      // When message was created
+    repository_data: RepositoryData {
+        name: String,           // Repository name
+        path: String,           // Local path
+        current_branch: String, // Active branch
+        remote_url: Option<String>, // Git remote
+        // ... additional metadata
+    }
+}
+```
+
+#### CommitData Message
+```rust
+ScanMessage::CommitData {
+    scanner_id,
+    timestamp,
+    commit_info: CommitInfo {
+        hash: String,           // Full commit hash
+        short_hash: String,     // Abbreviated hash
+        author_name: String,    // Commit author
+        author_email: String,   // Author email
+        committer_name: String, // Committer (may differ)
+        committer_email: String,
+        commit_time: SystemTime,
+        message: String,        // Commit message
+        parent_hashes: Vec<String>, // Parent commits
+        // ... additional commit data
+    }
+}
+```
+
+#### FileChange Message
+```rust
+ScanMessage::FileChange {
+    scanner_id,
+    timestamp,
+    file_change: FileChangeData {
+        commit_hash: String,    // Associated commit
+        path: String,           // File path
+        old_path: Option<String>, // For renames
+        change_type: ChangeType,  // Added/Modified/Deleted/Renamed/Copied
+        lines_added: u32,       // Diff statistics
+        lines_removed: u32,
+        file_content: Option<String>, // If FILE_CONTENT required
+        // ... additional change data
+    }
+}
+```
+
+## Scanner Integration
+
+The Scanner system generates repository data based on the combined requirements of all active plugins.
+
+### Requirement Declaration
+
+Plugins declare their data needs through `ScanRequires`:
+
+```rust
+impl Plugin for MyPlugin {
+    fn requirements(&self) -> ScanRequires {
+        // Declare what data this plugin needs
+        ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO
+        // Dependencies (COMMITS) included automatically
+    }
+}
+```
+
+### Requirement Aggregation
+
+The Plugin Manager aggregates requirements from all active plugins:
+
+```rust
+// Plugin Manager collects all requirements
+let mut combined_requirements = ScanRequires::NONE;
+for active_plugin in &self.active_plugins {
+    if let Some(plugin) = registry.get_plugin(&active_plugin.plugin_name) {
+        combined_requirements = combined_requirements.union(plugin.requirements());
+    }
+}
+
+// Scanner receives combined requirements
+scanner.set_requirements(combined_requirements);
+```
+
+### Scanner Optimization
+
+Scanner only generates data that plugins actually need:
+
+```rust
+// If no plugins need FILE_CONTENT, scanner skips file reading
+if !requirements.requires_file_content() {
+    // Skip expensive file I/O operations
+    return ScanMessage::FileChange {
+        file_change: FileChangeData {
+            file_content: None,  // No content provided
+            // ... other fields
+        }
+    };
+}
+```
+
+### Available Requirements
+
+#### `ScanRequires::REPOSITORY_INFO`
+- Repository metadata (name, path, branch, remote)
+- Lightweight, minimal performance impact
+- Useful for plugins that need context
+
+#### `ScanRequires::COMMITS`
+- Individual commit information (hash, author, message, timestamp)
+- Includes parent relationships for merge analysis
+- Medium performance impact
+
+#### `ScanRequires::FILE_CHANGES`
+- File modification details for each commit
+- Change types, paths, diff statistics
+- Automatically includes `COMMITS`
+- Higher performance impact
+
+#### `ScanRequires::FILE_CONTENT`
+- Actual file content at each commit/HEAD
+- Most expensive requirement
+- Automatically includes `FILE_CHANGES` and `COMMITS`
+- Use sparingly for static analysis plugins
+
+#### `ScanRequires::HISTORY`
+- Full commit history traversal
+- Enables historical trend analysis
+- Automatically includes `COMMITS`
+- Performance depends on repository size
+
+### Usage Patterns
+
+**Basic Repository Analysis**:
+```rust
+fn requirements(&self) -> ScanRequires {
+    ScanRequires::REPOSITORY_INFO
+}
+```
+
+**Commit Pattern Analysis**:
+```rust
+fn requirements(&self) -> ScanRequires {
+    ScanRequires::COMMITS  // Gets commit info only
+}
+```
+
+**Code Change Analysis**:
+```rust
+fn requirements(&self) -> ScanRequires {
+    ScanRequires::FILE_CHANGES  // Gets commits + file changes
+}
+```
+
+**Static Code Analysis**:
+```rust
+fn requirements(&self) -> ScanRequires {
+    ScanRequires::FILE_CONTENT  // Gets commits + changes + content
+}
+```
+
+**Historical Trend Analysis**:
+```rust
+fn requirements(&self) -> ScanRequires {
+    ScanRequires::HISTORY | ScanRequires::REPOSITORY_INFO
+}
+```
+
+## Notification System
+
+The Notification System provides event-driven communication across all system components.
+
+### Event Types
+
+The system publishes various event types:
+
+```rust
+pub enum Event {
+    System(SystemEvent),    // System lifecycle events
+    Queue(QueueEvent),      // Queue operations
+    Scan(ScanEvent),        // Scanner events
+    Plugin(PluginEvent),    // Plugin events
+}
+```
+
+### System Events
+```rust
+pub enum SystemEventType {
+    Started,        // System initialization complete
+    Shutdown,       // System shutting down
+    ConfigReload,   // Configuration reloaded
+}
+```
+
+### Queue Events
+```rust
+pub enum QueueEventType {
+    Started,        // Queue manager started
+    PublisherCreated,   // New publisher created
+    ConsumerCreated,    // New consumer created
+    MessagePublished,   // Message published to queue
+    MemoryPressure,     // Memory threshold exceeded
+}
+```
+
+### Scanner Events
+```rust
+pub enum ScanEventType {
+    Started,        // Scanner started
+    Progress,       // Scanning progress update
+    Completed,      // Scan completed successfully
+    Error,          // Scanner error occurred
+}
+```
+
+### Plugin Events
+```rust
+pub enum PluginEventType {
+    Discovered,     // Plugin discovered
+    Registered,     // Plugin registered
+    Activated,      // Plugin activated
+    Deactivated,    // Plugin deactivated
+    Error,          // Plugin error occurred
+}
+```
+
+### Subscribing to Events
+
+Processing plugins automatically get notification subscribers:
+
+```rust
+// Plugin Manager creates notification subscribers for active plugins
+for active_plugin in &self.active_plugins {
+    let subscriber_id = format!("plugin-{}-notifications", active_plugin.plugin_name);
+    let receiver = notification_manager.subscribe(
+        subscriber_id,
+        EventFilter::All,  // Receive all event types
+        format!("Plugin-{}", active_plugin.plugin_name)
+    )?;
+
+    // Store receiver to keep channel alive
+    self.notification_receivers.insert(subscriber_id, receiver);
+}
+```
+
+### Event Processing in Plugins
+
+Plugins can process events for coordination and monitoring:
+
+```rust
+impl Plugin for MyPlugin {
+    async fn initialize(&mut self) -> PluginResult<()> {
+        // Get notification receiver from plugin manager
+        // or create a custom subscriber
+
+        let services = get_services();
+        let mut notification_manager = services.notification_manager().await;
+        let receiver = notification_manager.subscribe(
+            "my-plugin-events".to_string(),
+            EventFilter::SystemOnly,  // Only system events
+            "MyPlugin".to_string()
+        )?;
+
+        // Spawn task to handle events
+        tokio::spawn(async move {
+            while let Some(event) = receiver.recv().await {
+                match event {
+                    Event::System(system_event) => {
+                        match system_event.event_type {
+                            SystemEventType::Shutdown => {
+                                // Prepare for shutdown
+                                self.prepare_shutdown().await;
+                            }
+                            _ => {}
+                        }
+                    }
+                    Event::Scan(scan_event) => {
+                        match scan_event.event_type {
+                            ScanEventType::Completed => {
+                                // Scanning finished - can now generate final reports
+                                self.generate_final_report().await;
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+```
+
+### Event Filtering
+
+Plugins can subscribe to specific event types:
+
+```rust
+use crate::notifications::api::{EventFilter, Event};
+
+// Subscribe to specific event types
+let receiver = notification_manager.subscribe(
+    "my-plugin".to_string(),
+    EventFilter::ScanOnly,    // Only scanner events
+    "MyPlugin".to_string()
+)?;
+
+// Available filters:
+// EventFilter::All          - All event types
+// EventFilter::SystemOnly   - System events only
+// EventFilter::QueueOnly    - Queue events only
+// EventFilter::ScanOnly     - Scanner events only
+// EventFilter::PluginOnly   - Plugin events only
+```
+
+## Complete Plugin Example
+
+Here's a comprehensive example showing how all components work together:
+
+```rust
+use crate::plugin::traits::{Plugin, ConsumerPlugin};
+use crate::plugin::types::{PluginInfo, PluginType, PluginFunction};
+use crate::scanner::types::{ScanRequires, ScanMessage};
+use crate::queue::api::QueueConsumer;
+use crate::plugin::args::PluginConfig;
+use crate::notifications::api::{Event, EventFilter};
+use std::collections::HashMap;
+
+pub struct AnalysisPlugin {
+    // Plugin state
+    initialized: bool,
+    consumer: Option<QueueConsumer>,
+
+    // Analysis data
+    commit_count: u64,
+    file_changes: HashMap<String, u32>,
+
+    // Configuration
+    verbose: bool,
+    output_format: String,
+}
+
+impl AnalysisPlugin {
+    pub fn new() -> Self {
+        Self {
+            initialized: false,
+            consumer: None,
+            commit_count: 0,
+            file_changes: HashMap::new(),
+            verbose: false,
+            output_format: "text".to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Plugin for AnalysisPlugin {
+    fn plugin_info(&self) -> PluginInfo {
+        PluginInfo {
+            name: "analysis".to_string(),
+            version: "1.0.0".to_string(),
+            description: "Repository analysis plugin".to_string(),
+            author: "Plugin Author".to_string(),
+            api_version: 20250101,
+            plugin_type: PluginType::Processing,  // Gets queue consumer
+            functions: vec![
+                PluginFunction {
+                    name: "analyse".to_string(),
+                    description: "Analyse repository patterns".to_string(),
+                    aliases: vec!["analyze".to_string(), "stats".to_string()],
+                }
+            ],
+            required: (ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO).bits(),
+            auto_active: false,
+        }
+    }
+
+    fn plugin_type(&self) -> PluginType {
+        PluginType::Processing
+    }
+
+    fn advertised_functions(&self) -> Vec<PluginFunction> {
+        vec![
+            PluginFunction {
+                name: "analyse".to_string(),
+                description: "Analyse repository patterns".to_string(),
+                aliases: vec!["analyze".to_string(), "stats".to_string()],
+            }
+        ]
+    }
+
+    fn requirements(&self) -> ScanRequires {
+        ScanRequires::FILE_CHANGES | ScanRequires::REPOSITORY_INFO
+    }
+
+    async fn initialize(&mut self) -> PluginResult<()> {
+        if self.verbose {
+            println!("Initializing analysis plugin...");
+        }
+        self.initialized = true;
+        Ok(())
+    }
+
+    async fn execute(&mut self, _args: &[String]) -> PluginResult<()> {
+        // Direct execution (if needed)
+        if !self.initialized {
+            return Err(PluginError::ExecutionError {
+                plugin_name: "analysis".to_string(),
+                operation: "execute".to_string(),
+                cause: "Plugin not initialized".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> PluginResult<()> {
+        if self.verbose {
+            println!("Analysis plugin cleanup - processed {} commits", self.commit_count);
+        }
+        Ok(())
+    }
+
+    async fn parse_plugin_arguments(
+        &mut self,
+        args: &[String],
+        config: &PluginConfig,
+    ) -> PluginResult<()> {
+        // Parse CLI arguments using simple parser
+        let settings = PluginSettings::from_cli_args("analyse".to_string(), args.to_vec())?;
+
+        // Apply settings
+        self.verbose = settings.has_flag("verbose") || config.get_bool("verbose", false);
+        self.output_format = settings.get_arg("format")
+            .cloned()
+            .unwrap_or_else(|| config.get_string("output_format", "text"));
+
+        if self.verbose {
+            println!("Analysis plugin configured: format={}, verbose={}",
+                    self.output_format, self.verbose);
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsumerPlugin for AnalysisPlugin {
+    async fn start_consuming(&mut self, consumer: QueueConsumer) -> PluginResult<()> {
+        if self.verbose {
+            println!("Starting message consumption...");
+        }
+
+        self.consumer = Some(consumer.clone());
+
+        // Spawn background task for message processing
+        let verbose = self.verbose;
+        tokio::spawn(async move {
+            loop {
+                match consumer.receive_message().await {
+                    Ok(message) => {
+                        if let Err(e) = Self::process_message(message, verbose).await {
+                            log::error!("Error processing message: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to receive message: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop_consuming(&mut self) -> PluginResult<()> {
+        if let Some(consumer) = &self.consumer {
+            consumer.close().await?;
+        }
+        self.consumer = None;
+
+        if self.verbose {
+            println!("Stopped consuming messages");
+        }
+        Ok(())
+    }
+}
+
+impl AnalysisPlugin {
+    async fn process_message(message: ScanMessage, verbose: bool) -> PluginResult<()> {
+        match message {
+            ScanMessage::RepositoryData { repository_data, .. } => {
+                if verbose {
+                    println!("Processing repository: {}", repository_data.name);
+                }
+            }
+            ScanMessage::CommitData { commit_info, .. } => {
+                if verbose {
+                    println!("Processing commit: {} by {}",
+                            commit_info.short_hash, commit_info.author_name);
+                }
+                // Increment commit counter (would need shared state in real implementation)
+            }
+            ScanMessage::FileChange { file_change, .. } => {
+                if verbose {
+                    println!("File changed: {} ({})",
+                            file_change.path, file_change.change_type);
+                }
+                // Track file changes (would need shared state in real implementation)
+            }
+            ScanMessage::ScanCompleted { .. } => {
+                if verbose {
+                    println!("Scan completed - generating analysis report");
+                }
+                // Generate final analysis report
+            }
+            ScanMessage::ScanError { error_message, .. } => {
+                log::error!("Scanner error: {}", error_message);
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+## Best Practices
+
+### Plugin Design
+
+1. **Single Responsibility**: Each plugin should have a clear, focused purpose
+2. **Resource Management**: Always clean up resources in `cleanup()`
+3. **Error Handling**: Provide meaningful error messages with context
+4. **Performance**: Consider memory usage and processing time
+5. **Configuration**: Support both CLI and TOML configuration
+
+### Queue Usage
+
+1. **Processing Plugins**: Implement `ConsumerPlugin` for real-time processing
+2. **Output Plugins**: Use `PluginType::Output` to avoid unnecessary consumers
+3. **Message Handling**: Process messages efficiently to avoid queue backlog
+4. **Error Recovery**: Handle message processing errors gracefully
+
+### Scanner Requirements
+
+1. **Minimal Requirements**: Only request data you actually need
+2. **Performance Impact**: `FILE_CONTENT` is expensive - use judiciously
+3. **Dependency Awareness**: Understand automatic requirement inclusion
+4. **Testing**: Test with different requirement combinations
+
+### Event Integration
+
+1. **Lifecycle Events**: Use system events for coordination
+2. **Scanner Events**: React to scan completion for final processing
+3. **Error Events**: Handle errors from other components appropriately
+4. **Subscription Management**: Keep event receivers alive as needed
+
+## Common Patterns
+
+### Data Collection and Analysis
+
+```rust
+// 1. Collect data during scan via queue messages
+// 2. Process incrementally or batch at end
+// 3. Generate reports when scan completes (via events)
+```
+
+### Multi-Stage Processing
+
+```rust
+// Processing Plugin (Stage 1) → Processing Plugin (Stage 2) → Output Plugin
+// Use events to coordinate between stages
+```
+
+### Configuration-Driven Behavior
+
+```rust
+// Support both runtime (CLI) and persistent (TOML) configuration
+// CLI overrides TOML overrides defaults
+```
+
+### Resource Monitoring
+
+```rust
+// Monitor queue lag, memory usage via system APIs
+// Implement backpressure and cleanup as needed
+```
+
+## See Also
+
+- [Plugin Functions Documentation](plugin_functions.md)
+- [CLI Integration Documentation](cli_integration.md)
+- [ScanRequires Documentation](scan_requires.md)
+- [PluginInfo Documentation](plugin_info.md)
+- [Plugin Author Guide](plugin_author_guide.md)

--- a/src/app/cli/display.rs
+++ b/src/app/cli/display.rs
@@ -1,6 +1,6 @@
 //! CLI display utilities for formatting output
 
-use crate::plugin::types::PluginMetadata;
+use crate::plugin::types::PluginInfo;
 use tabled::{
     settings::{
         object::{Columns, Object, Rows},
@@ -25,7 +25,7 @@ struct DisplayRow {
 
 /// Display plugin information in a simple formatted table using tabled
 /// Returns an error if plugin data is invalid or malformed
-pub fn display_plugin_table(plugins: Vec<PluginMetadata>, use_color: bool) -> Result<(), String> {
+pub fn display_plugin_table(plugins: Vec<PluginInfo>, use_color: bool) -> Result<(), String> {
     if plugins.is_empty() {
         eprintln!("No plugins discovered.");
         return Ok(());
@@ -135,14 +135,16 @@ fn print_table_with_separator(table: &Table) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::types::{PluginFunction, PluginMetadata};
+    use crate::plugin::types::{PluginFunction, PluginInfo, PluginType};
 
-    fn create_test_plugin(name: &str, description: &str, functions: Vec<&str>) -> PluginMetadata {
-        PluginMetadata {
+    fn create_test_plugin(name: &str, description: &str, functions: Vec<&str>) -> PluginInfo {
+        PluginInfo {
             name: name.to_string(),
             version: "1.0.0".to_string(),
             description: description.to_string(),
             author: "Test Author".to_string(),
+            api_version: 20250101,
+            plugin_type: PluginType::Processing,
             functions: functions
                 .into_iter()
                 .map(|f| PluginFunction {
@@ -151,8 +153,8 @@ mod tests {
                     aliases: vec![],
                 })
                 .collect(),
-            requires_file_content: false,
-            requires_historical_content: false,
+            required: 0, // ScanRequires::NONE
+            auto_active: false,
         }
     }
 

--- a/src/app/cli/display.rs
+++ b/src/app/cli/display.rs
@@ -1,6 +1,7 @@
 //! CLI display utilities for formatting output
 
 use crate::plugin::types::PluginInfo;
+use crate::scanner::types::ScanRequires;
 use tabled::{
     settings::{
         object::{Columns, Object, Rows},
@@ -153,7 +154,7 @@ mod tests {
                     aliases: vec![],
                 })
                 .collect(),
-            required: 0, // ScanRequires::NONE
+            required: ScanRequires::NONE,
             auto_active: false,
         }
     }

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -9,10 +9,10 @@
 pub use crate::plugin::manager::PluginManager;
 
 // Error handling
-pub use crate::plugin::error::{PluginError, PluginResult};
+pub use crate::plugin::error::PluginError;
 
 // Plugin metadata and information
-pub use crate::plugin::types::{PluginInfo, PluginMetadata};
+pub use crate::plugin::types::PluginInfo;
 
 // Plugin configuration and arguments
 

--- a/src/plugin/builtin/dump.rs
+++ b/src/plugin/builtin/dump.rs
@@ -236,11 +236,15 @@ impl Plugin for DumpPlugin {
             description: "Dump repository data for debugging purposes".to_string(),
             author: "RepoStats".to_string(),
             api_version: 20250101,
+            plugin_type: self.plugin_type(),
+            functions: self.advertised_functions(),
+            required: self.requirements().bits(),
+            auto_active: false, // Dump is activated explicitly
         }
     }
 
     fn plugin_type(&self) -> PluginType {
-        PluginType::Output
+        PluginType::Processing
     }
 
     fn advertised_functions(&self) -> Vec<PluginFunction> {
@@ -432,7 +436,7 @@ mod tests {
         assert!(!plugin.initialized);
         assert_eq!(plugin.plugin_info().name, "dump");
         assert_eq!(plugin.plugin_info().version, "1.0.0");
-        assert_eq!(plugin.plugin_type(), PluginType::Output);
+        assert_eq!(plugin.plugin_type(), PluginType::Processing);
     }
 
     #[tokio::test]

--- a/src/plugin/builtin/dump.rs
+++ b/src/plugin/builtin/dump.rs
@@ -238,7 +238,7 @@ impl Plugin for DumpPlugin {
             api_version: 20250101,
             plugin_type: self.plugin_type(),
             functions: self.advertised_functions(),
-            required: self.requirements().bits(),
+            required: self.requirements(),
             auto_active: false, // Dump is activated explicitly
         }
     }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -293,6 +293,10 @@ mod tests {
                 description: "Mock plugin".to_string(),
                 author: "Test".to_string(),
                 api_version: 20250101,
+                plugin_type: self.plugin_type(),
+                functions: self.advertised_functions(),
+                required: self.requirements().bits(),
+                auto_active: false,
             }
         }
 

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -295,7 +295,7 @@ mod tests {
                 api_version: 20250101,
                 plugin_type: self.plugin_type(),
                 functions: self.advertised_functions(),
-                required: self.requirements().bits(),
+                required: self.requirements(),
                 auto_active: false,
             }
         }

--- a/src/plugin/tests/utils.rs
+++ b/src/plugin/tests/utils.rs
@@ -47,7 +47,7 @@ impl MockPlugin {
                     description: "Test function".to_string(),
                     aliases: vec![],
                 }],
-                required: 0, // ScanRequires::NONE
+                required: ScanRequires::NONE,
                 auto_active: false,
             },
             initialized: false,

--- a/src/plugin/tests/utils.rs
+++ b/src/plugin/tests/utils.rs
@@ -41,6 +41,14 @@ impl MockPlugin {
                 description: "Mock plugin for testing".to_string(),
                 author: "Test Author".to_string(),
                 api_version: 20250101,
+                plugin_type: crate::plugin::types::PluginType::Processing,
+                functions: vec![crate::plugin::types::PluginFunction {
+                    name: "test".to_string(),
+                    description: "Test function".to_string(),
+                    aliases: vec![],
+                }],
+                required: 0, // ScanRequires::NONE
+                auto_active: false,
             },
             initialized: false,
             executed: false,

--- a/src/plugin/traits.rs
+++ b/src/plugin/traits.rs
@@ -112,7 +112,7 @@ mod tests {
                         description: "Test function".to_string(),
                         aliases: vec![],
                     }],
-                    required: 0, // ScanRequires::NONE
+                    required: ScanRequires::NONE,
                     auto_active: false,
                 },
                 initialized: false,
@@ -400,7 +400,7 @@ mod tests {
             api_version: 20250101,
             plugin_type: crate::plugin::types::PluginType::Processing,
             functions: vec![],
-            required: 0,
+            required: ScanRequires::NONE,
             auto_active: false,
         };
 

--- a/src/plugin/traits.rs
+++ b/src/plugin/traits.rs
@@ -106,6 +106,14 @@ mod tests {
                     description: "Mock plugin for testing".to_string(),
                     author: "Test Author".to_string(),
                     api_version: 20250101,
+                    plugin_type: crate::plugin::types::PluginType::Processing,
+                    functions: vec![crate::plugin::types::PluginFunction {
+                        name: "test".to_string(),
+                        description: "Test function".to_string(),
+                        aliases: vec![],
+                    }],
+                    required: 0, // ScanRequires::NONE
+                    auto_active: false,
                 },
                 initialized: false,
                 executed: false,
@@ -390,6 +398,10 @@ mod tests {
             description: "Test plugin".to_string(),
             author: "Author".to_string(),
             api_version: 20250101,
+            plugin_type: crate::plugin::types::PluginType::Processing,
+            functions: vec![],
+            required: 0,
+            auto_active: false,
         };
 
         let info2 = info1.clone();

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -13,6 +13,10 @@ pub struct PluginInfo {
     pub description: String,
     pub author: String,
     pub api_version: u32,
+    pub plugin_type: PluginType,
+    pub functions: Vec<PluginFunction>,
+    pub required: u64, // ScanRequires value
+    pub auto_active: bool,
 }
 
 /// Plugin function metadata
@@ -24,6 +28,23 @@ pub struct PluginFunction {
 }
 
 /// Plugin type classification
+///
+/// Defines the functional category and queue interaction behavior of plugins:
+///
+/// - `Processing`: Plugins that actively consume and process queue messages.
+///   This includes data transformation, analysis, debugging, and monitoring plugins.
+///   Examples: statistical analyzers, format converters, debug dumpers.
+///   **Always gets queue subscribers for message processing.**
+///
+/// - `Output`: Plugins that generate final reports, exports, or files.
+///   These plugins typically work with processed data but don't need live queue access.
+///   Examples: report generators, file exporters, summary creators.
+///   **Does not get queue subscribers.**
+///
+/// - `Notification`: Event-driven plugins that respond to system notifications.
+///   These plugins react to system events rather than processing message queues.
+///   Examples: webhook notifiers, system monitors, health checkers.
+///   **Does not get queue subscribers.**
 #[derive(Debug, Clone, PartialEq)]
 pub enum PluginType {
     Processing,
@@ -53,38 +74,6 @@ impl PluginId {
 
     pub fn increment(&mut self) {
         self.0 += 1;
-    }
-}
-
-/// Plugin metadata exposed to external systems for display/help
-#[derive(Debug, Clone)]
-pub struct PluginMetadata {
-    pub name: String,
-    pub version: String,
-    pub description: String,
-    pub author: String,
-    pub functions: Vec<PluginFunction>,
-    pub requires_file_content: bool,
-    pub requires_historical_content: bool,
-}
-
-/// Simplified plugin proxy for controlled access
-#[derive(Debug, Clone)]
-pub struct PluginProxy {
-    /// Plugin metadata
-    pub metadata: PluginMetadata,
-}
-
-impl PluginProxy {
-    /// Get plugin metadata for display/help systems
-    pub fn get_metadata(&self) -> crate::plugin::error::PluginResult<PluginMetadata> {
-        Ok(self.metadata.clone())
-    }
-
-    /// Configure plugin with command-line arguments (placeholder)
-    pub fn parse_arguments(&self, _args: &[String]) -> crate::plugin::error::PluginResult<()> {
-        // TODO: Implement argument parsing through PluginManager reference
-        Ok(())
     }
 }
 

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -3,6 +3,7 @@
 //! This module contains the core data structures used throughout
 //! the plugin system for metadata, configuration, and plugin management.
 
+use crate::scanner::types::ScanRequires;
 use std::path::PathBuf;
 
 /// Plugin metadata information
@@ -15,7 +16,7 @@ pub struct PluginInfo {
     pub api_version: u32,
     pub plugin_type: PluginType,
     pub functions: Vec<PluginFunction>,
-    pub required: u64, // ScanRequires value
+    pub required: ScanRequires,
     pub auto_active: bool,
 }
 


### PR DESCRIPTION
  - Change PluginInfo.required from u64 to ScanRequires type for better type safety
  - Add 5 helper methods to eliminate duplicated registry lookup patterns
  - Remove inappropriate validation warning for auto-active plugins without functions
  - Update all PluginInfo creation sites across plugin system components
 