### PR TITLE
RS-28 feat(scanner): add git-based checkout support and repository configuration

### DIFF
--- a/src/app/cli/args.rs
+++ b/src/app/cli/args.rs
@@ -163,7 +163,30 @@ pub struct Args {
     pub checkout_rev: Option<String>,
 }
 
+/// Settings for file checkout functionality
+#[derive(Debug, Clone)]
+pub struct CheckoutSettings {
+    pub checkout_template: Option<String>,
+    pub keep_checkouts: bool,
+    pub force_overwrite: bool,
+    pub default_revision: Option<String>,
+}
+
 impl Args {
+    /// Extract checkout settings from CLI arguments
+    pub fn checkout_settings(&self) -> Option<CheckoutSettings> {
+        if self.checkout_dir.is_none() {
+            return None;
+        }
+
+        Some(CheckoutSettings {
+            checkout_template: self.checkout_dir.clone(),
+            keep_checkouts: self.checkout_keep && !self.no_checkout_keep,
+            force_overwrite: self.checkout_force,
+            default_revision: self.checkout_rev.clone(),
+        })
+    }
+
     /// Get normalized repository list with explicit default to current directory
     ///
     /// This method makes the default behavior explicit by converting empty repository

--- a/src/app/cli/mod.rs
+++ b/src/app/cli/mod.rs
@@ -7,6 +7,9 @@ pub mod command_segmenter;
 pub mod date_parser;
 pub mod display;
 
+// Re-export commonly used types
+pub use args::CheckoutSettings;
+
 pub struct RequiredArgs {
     pub global_args: Vec<String>,
     pub config_file: Option<PathBuf>,

--- a/src/scanner/task/git_ops.rs
+++ b/src/scanner/task/git_ops.rs
@@ -471,6 +471,7 @@ impl ScannerTask {
             insertions: 0,
             deletions: 0,
             is_binary: false,
+            checkout_path: None,
         };
 
         Ok(vec![ScanMessage::FileChange {
@@ -582,6 +583,7 @@ impl ScannerTask {
             insertions: 10,
             deletions: 5,
             is_binary: false,
+            checkout_path: None,
         };
 
         file_change_messages.push(ScanMessage::FileChange {

--- a/src/scanner/types.rs
+++ b/src/scanner/types.rs
@@ -2,6 +2,7 @@
 //!
 //! Shared types and enums used throughout the scanner module.
 
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 /// Bitflags for scanner requirements from plugins
@@ -184,6 +185,8 @@ pub struct FileChangeData {
     pub insertions: usize,
     pub deletions: usize,
     pub is_binary: bool,
+    /// Path to checkout directory where file content is available (if FILE_CONTENT requirement is active)
+    pub checkout_path: Option<PathBuf>,
 }
 
 /// Repository metadata information


### PR DESCRIPTION
Introduces support for checking out files from a git repository using the gix library.

- Adds repository path and default revision configuration to CheckoutManager.
- Implements placeholder methods for resolving git revisions and extracting files from commits.
- Updates the checkout directory creation process to integrate git operations.
- Expands error handling to cover git-related errors.
- Refactors and extends tests to accommodate new repository and revision parameters, with git-dependent tests temporarily disabled pending full implementation.