### PR TITLE
RS- 28 file checkout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,12 @@ flexi_logger = "0.31"
 chrono = "0.4.41"
 glob = "0.3"
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "fs"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "fs", "signal"] }
 thiserror = "2.0"
 tabled = "0.19"
 regex = "1"
 once_cell = "1.20"
+libc = "0.2"
 
 [build-dependencies]
 chrono = "0.4"

--- a/src/plugin/builtin/dump.rs
+++ b/src/plugin/builtin/dump.rs
@@ -51,8 +51,7 @@ impl DumpPlugin {
 
     /// Check if a message type is a scan message that should be deserialized
     fn is_scan_message(message_type: &str) -> bool {
-        message_type.starts_with("repository_data")
-            || message_type.starts_with("scan_")
+        message_type.starts_with("scan_")
             || message_type.starts_with("commit_")
             || message_type.starts_with("file_")
     }
@@ -116,8 +115,8 @@ impl DumpPlugin {
 
     /// Format message in compact format
     fn format_compact(msg: &Message, scan_message: Option<&ScanMessage>) -> String {
-        if msg.header.message_type.starts_with("repository_data") {
-            if let Some(ScanMessage::RepositoryData {
+        if msg.header.message_type.starts_with("scan_started") {
+            if let Some(ScanMessage::ScanStarted {
                 repository_data, ..
             }) = scan_message
             {
@@ -161,7 +160,7 @@ impl DumpPlugin {
         scan_message: Option<&ScanMessage>,
         show_headers: bool,
     ) -> String {
-        if let Some(ScanMessage::RepositoryData {
+        if let Some(ScanMessage::ScanStarted {
             repository_data, ..
         }) = scan_message
         {
@@ -377,7 +376,7 @@ impl ConsumerPlugin for DumpPlugin {
                                 // Track scanner lifecycle
                                 if let Ok(scan_message) = serde_json::from_str::<ScanMessage>(&msg.data) {
                                     match scan_message {
-                                        ScanMessage::RepositoryData { scanner_id, .. } => {
+                                        ScanMessage::ScanStarted { scanner_id, .. } => {
                                             active_scanners.insert(scanner_id.clone());
                                             log::debug!("DumpPlugin: Started tracking scanner: {}", scanner_id);
                                         }

--- a/src/scanner/types.rs
+++ b/src/scanner/types.rs
@@ -384,7 +384,7 @@ fn format_system_time(time: &std::time::SystemTime) -> String {
 /// Scanner messages for repository scan data
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum ScanMessage {
-    RepositoryData {
+    ScanStarted {
         scanner_id: String,
         timestamp: SystemTime,
         repository_data: RepositoryData,
@@ -418,7 +418,7 @@ impl ScanMessage {
     /// Get the message type string for queue publishing
     pub fn message_type(&self) -> &'static str {
         match self {
-            ScanMessage::RepositoryData { .. } => "repository_data",
+            ScanMessage::ScanStarted { .. } => "scan_started",
             ScanMessage::CommitData { .. } => "commit_data",
             ScanMessage::FileChange { .. } => "file_change",
             ScanMessage::ScanCompleted { .. } => "scan_completed",


### PR DESCRIPTION
Introduces a coordinated shutdown mechanism for graceful application termination, including signal handling and shutdown propagation.
 - Implements full file content checkout for specific commits, enabling plugins and scanners to access checked-out files as needed.
 - Refactors checkout management to support thread-safe, shared access using Arc<Mutex<>>.
 - Enhances repository validation to check for the existence of specified git references.
 - Updates scanner and plugin interfaces to support and utilize file content checkouts.
 - Refactors and renames scan lifecycle messages for clarity (e.g., RepositoryData → ScanStarted).
 - Adds and updates tests to cover new shutdown and checkout functionality.
 - Updates dependencies to support new features (e.g., adds libc, enables tokio signal handling).
