### PR TITLE
RS-43 Simplify color config and remove raw output format

### DIFF
--- a/src/plugin/builtin/dump/args.rs
+++ b/src/plugin/builtin/dump/args.rs
@@ -57,13 +57,8 @@ impl DumpPlugin {
         self.request_file_content = matches.get_flag("checkout");
         self.request_file_info = matches.get_flag("files");
         self.output_file = matches.get_one::<PathBuf>("outfile").cloned();
-        let auto = std::io::IsTerminal::is_terminal(&std::io::stdout());
-        let base = config.use_colors.unwrap_or(auto);
-        self.use_colors = if self.output_file.is_some() {
-            false
-        } else {
-            base
-        };
+        self.use_colors = config.use_colors;
+
         Ok(())
     }
 
@@ -111,8 +106,6 @@ impl DumpPlugin {
         {
             "json" => OutputFormat::Json,
             "compact" => OutputFormat::Compact,
-            // Allow opting into raw explicitly via config: default_format = "raw"
-            "raw" => OutputFormat::Raw,
             _ => OutputFormat::Text,
         }
     }
@@ -126,7 +119,7 @@ mod tests {
     #[test]
     fn test_plugin_config_default() {
         let config = PluginConfig::default();
-        assert!(config.use_colors.is_none());
+        assert!(!config.use_colors);
         assert!(config.toml_config.is_empty());
     }
 
@@ -149,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_plugin_arg_parser() {
-        let parser = PluginArgParser::new("test", "Test plugin", "1.0.0", Some(true))
+        let parser = PluginArgParser::new("test", "Test plugin", "1.0.0", false)
             .args(DumpPlugin::format_args());
 
         let matches = parser
@@ -160,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_determine_format() {
-        let parser = PluginArgParser::new("test", "Test plugin", "1.0.0", Some(false))
+        let parser = PluginArgParser::new("test", "Test plugin", "1.0.0", false)
             .args(DumpPlugin::format_args());
         let config = PluginConfig::default();
 

--- a/src/plugin/builtin/dump/consumer.rs
+++ b/src/plugin/builtin/dump/consumer.rs
@@ -125,9 +125,6 @@ impl DumpPlugin {
             OutputFormat::Compact => {
                 super::format::format_compact_typed(typed_msg, show_headers, use_colors)
             }
-            OutputFormat::Raw => {
-                super::format::format_text_typed(typed_msg, show_headers, use_colors)
-            }
             OutputFormat::Text => {
                 super::format::format_pretty_text_typed(typed_msg, show_headers, use_colors)
             }

--- a/src/plugin/builtin/dump/format.rs
+++ b/src/plugin/builtin/dump/format.rs
@@ -1,37 +1,7 @@
 //! Formatting utilities for DumpPlugin (split from monolithic file)
-use crate::plugin::builtin::dump::OutputFormat;
 use crate::queue::typed::TypedMessage;
 use crate::scanner::api::ScanMessage;
 use serde_json::json;
-
-// Public (within crate::plugin::builtin::dump) helpers
-pub(super) fn format_typed_message_direct(
-    typed_msg: &TypedMessage<ScanMessage>,
-    output_format: OutputFormat,
-    show_headers: bool,
-    use_colors: bool,
-) -> String {
-    match output_format {
-        OutputFormat::Json => format_json_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Compact => format_compact_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Raw => format_text_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Text => format_pretty_text_typed(typed_msg, show_headers, use_colors),
-    }
-}
-
-pub(super) fn format_typed_message_direct_with_color(
-    typed_msg: &TypedMessage<ScanMessage>,
-    output_format: OutputFormat,
-    show_headers: bool,
-    use_colors: bool,
-) -> String {
-    match output_format {
-        OutputFormat::Json => format_json_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Compact => format_compact_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Raw => format_text_typed(typed_msg, show_headers, use_colors),
-        OutputFormat::Text => format_pretty_text_typed(typed_msg, show_headers, use_colors),
-    }
-}
 
 pub fn format_json_typed(
     typed_msg: &TypedMessage<ScanMessage>,
@@ -59,8 +29,6 @@ pub fn format_json_typed(
 
     obj.insert("message_type".into(), json!(typed_msg.header.message_type));
     obj.insert("timestamp".into(), json!(iso8601));
-    obj.insert("timestamp_seconds".into(), json!(secs));
-    obj.insert("timestamp_nanos".into(), json!(nanos));
     obj.insert("scan_message".into(), json!(typed_msg.content));
 
     Value::Object(obj).to_string()
@@ -69,35 +37,39 @@ pub fn format_json_typed(
 pub fn format_compact_typed(
     typed_msg: &TypedMessage<ScanMessage>,
     show_headers: bool,
-    _color_enabled: bool,
+    color_enabled: bool,
 ) -> String {
+    use crate::core::styles::StyleRole;
     use crate::scanner::api::ScanMessage as SM;
     use chrono::{DateTime, Local};
+
+    let paint = |role: StyleRole, text: &str| role.paint(text, color_enabled);
 
     let header_prefix = if show_headers {
         format!(
             "{}:{}:",
-            typed_msg.header.sequence, typed_msg.header.producer_id
+            paint(StyleRole::Header, &typed_msg.header.sequence.to_string()),
+            paint(StyleRole::Header, &typed_msg.header.producer_id)
         )
     } else {
         String::new()
     };
 
     let format_duration = |duration: std::time::Duration| -> String {
-        let total_millis = duration.as_millis();
-        let minutes = total_millis / 60_000;
-        let seconds = (total_millis % 60_000) / 1_000;
-        let millis = total_millis % 1_000;
+        let total_nanos = duration.as_nanos();
+        let minutes = total_nanos / 60_000_000_000;
+        let seconds = (total_nanos % 60_000_000_000) / 1_000_000_000;
+        let nanos = total_nanos % 1_000_000_000;
         if minutes > 0 {
-            format!("{}m{}.{}s", minutes, seconds, millis / 100)
+            format!("{}m{}.{:06}s", minutes, seconds, nanos / 1000)
         } else {
-            format!("{}.{}s", seconds, millis / 100)
+            format!("{}.{:06}s", seconds, nanos / 1000)
         }
     };
 
     let format_timestamp = |ts: &std::time::SystemTime| -> String {
         DateTime::<Local>::try_from(*ts)
-            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+            .map(|dt| dt.format("%Y-%m-%d,%H:%M:%S%.f").to_string())
             .unwrap_or_else(|_| "invalid-time".into())
     };
 
@@ -105,7 +77,7 @@ pub fn format_compact_typed(
         if insertions == 0 && deletions == 0 {
             String::new()
         } else {
-            format!("+{}/{}", insertions, deletions)
+            format!("+{}/-{}", insertions, deletions)
         }
     };
 
@@ -121,18 +93,19 @@ pub fn format_compact_typed(
                 .or(repository_data.default_branch.as_deref())
                 .unwrap_or("(default)");
             format!(
-                "{}scan_started:{}:{}:{}:{}",
+                "{}{}:{}:{}:{}:{}",
                 header_prefix,
-                scanner_id,
-                repository_data.path,
-                branch,
+                paint(StyleRole::Header, "scan_started"),
+                paint(StyleRole::Key, scanner_id),
+                paint(StyleRole::Value, &repository_data.path),
+                paint(StyleRole::Value, branch),
                 format_timestamp(timestamp)
             )
         }
         SM::CommitData {
             commit_info,
             scanner_id,
-            ..
+            timestamp,
         } => {
             let hash8 = if commit_info.hash.len() > 8 {
                 &commit_info.hash[..8]
@@ -151,14 +124,18 @@ pub fn format_compact_typed(
                     .join(",")
             };
             format!(
-                "{}commit:{}:{}:{}:{}:{} <{}>",
+                "{}{}:{}:{}:{}:{}:{}:{}",
                 header_prefix,
-                scanner_id,
-                hash8,
+                paint(StyleRole::Header, "commit"),
+                paint(StyleRole::Key, scanner_id),
+                paint(StyleRole::Value, hash8),
                 lines,
                 parents,
-                commit_info.author_name,
-                commit_info.author_email
+                paint(
+                    StyleRole::Value,
+                    &format!("{}:{}", commit_info.author_name, commit_info.author_email)
+                ),
+                format_timestamp(timestamp)
             )
         }
         SM::FileChange {
@@ -176,8 +153,13 @@ pub fn format_compact_typed(
             };
             let lines = format_lines(change_data.insertions, change_data.deletions);
             format!(
-                "{}file_change:{}:{}:{}:{}",
-                header_prefix, scanner_id, change_type, lines, file_path
+                "{}{}:{}:{}:{}:{}",
+                header_prefix,
+                paint(StyleRole::Header, "file_change"),
+                paint(StyleRole::Key, scanner_id),
+                paint(StyleRole::Value, change_type),
+                lines,
+                paint(StyleRole::Value, file_path)
             )
         }
         SM::ScanCompleted {
@@ -186,9 +168,10 @@ pub fn format_compact_typed(
             let lines = format_lines(stats.total_insertions, stats.total_deletions);
             let duration = format_duration(stats.scan_duration);
             format!(
-                "{}scan_completed:{}:{}:{}:{}:{}",
+                "{}{}:{}:{}:{}:{}:{}",
                 header_prefix,
-                scanner_id,
+                paint(StyleRole::Header, "scan_completed"),
+                paint(StyleRole::Key, scanner_id),
                 stats.total_commits,
                 stats.total_files_changed,
                 lines,
@@ -202,171 +185,14 @@ pub fn format_compact_typed(
             ..
         } => {
             format!(
-                "{}scan_error:{}:{}:{}",
-                header_prefix, scanner_id, error, context
-            )
-        }
-    }
-}
-
-pub(super) fn format_text_typed(
-    typed_msg: &TypedMessage<ScanMessage>,
-    show_headers: bool,
-    color_enabled: bool,
-) -> String {
-    if typed_msg.header.message_type.starts_with("scan_started") {
-        format_repository_data_text_typed(typed_msg, show_headers, color_enabled)
-    } else {
-        format_regular_message_text_typed(typed_msg, show_headers, color_enabled)
-    }
-}
-
-fn format_repository_data_text_typed(
-    typed_msg: &TypedMessage<ScanMessage>,
-    show_headers: bool,
-    color_enabled: bool,
-) -> String {
-    if let ScanMessage::ScanStarted {
-        repository_data, ..
-    } = &typed_msg.content
-    {
-        if show_headers {
-            format!(
-                "[{}] Repository Metadata:\n  Path: {}",
-                typed_msg.header.sequence, repository_data.path
-            )
-        } else {
-            format!("Repository: {}", repository_data.path)
-        }
-    } else {
-        format_regular_message_text_typed(typed_msg, show_headers, color_enabled)
-    }
-}
-
-fn format_regular_message_text_typed(
-    typed_msg: &TypedMessage<ScanMessage>,
-    show_headers: bool,
-    _color_enabled: bool,
-) -> String {
-    use crate::scanner::api::ScanMessage as SM;
-    use chrono::{DateTime, Local};
-
-    let format_duration = |duration: std::time::Duration| -> String {
-        let total_millis = duration.as_millis();
-        let minutes = total_millis / 60_000;
-        let seconds = (total_millis % 60_000) / 1_000;
-        let millis = total_millis % 1_000;
-        if minutes > 0 {
-            format!("{}m{}.{}s", minutes, seconds, millis / 100)
-        } else {
-            format!("{}.{}s", seconds, millis / 100)
-        }
-    };
-
-    let format_timestamp = |ts: &std::time::SystemTime| -> String {
-        DateTime::<Local>::try_from(*ts)
-            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
-            .unwrap_or_else(|_| "invalid-time".into())
-    };
-
-    let format_lines = |insertions: usize, deletions: usize| -> String {
-        if insertions == 0 && deletions == 0 {
-            "no changes".to_string()
-        } else {
-            format!("+{}/{} lines", insertions, deletions)
-        }
-    };
-
-    let content_text = match &typed_msg.content {
-        SM::ScanStarted {
-            repository_data,
-            scanner_id,
-            timestamp,
-        } => {
-            let branch = repository_data
-                .git_ref
-                .as_deref()
-                .or(repository_data.default_branch.as_deref())
-                .unwrap_or("default");
-            format!(
-                "Scan {} started for repository {} (branch: {}) at {}",
-                scanner_id,
-                repository_data.path,
-                branch,
-                format_timestamp(timestamp)
-            )
-        }
-        SM::CommitData { commit_info, .. } => {
-            let hash8 = if commit_info.hash.len() > 8 {
-                &commit_info.hash[..8]
-            } else {
-                &commit_info.hash
-            };
-            format!(
-                "Commit {} by {} <{}>: {} ({})",
-                hash8,
-                commit_info.author_name,
-                commit_info.author_email,
-                commit_info.message.lines().next().unwrap_or(""),
-                format_lines(commit_info.insertions, commit_info.deletions)
-            )
-        }
-        SM::FileChange {
-            file_path,
-            change_data,
-            ..
-        } => {
-            let change_desc = match change_data.change_type {
-                crate::scanner::types::ChangeType::Added => "added",
-                crate::scanner::types::ChangeType::Modified => "modified",
-                crate::scanner::types::ChangeType::Deleted => "deleted",
-                crate::scanner::types::ChangeType::Renamed => "renamed",
-                crate::scanner::types::ChangeType::Copied => "copied",
-            };
-            format!(
-                "File {} {}: {}",
-                file_path,
-                change_desc,
-                format_lines(change_data.insertions, change_data.deletions)
-            )
-        }
-        SM::ScanCompleted {
-            stats, timestamp, ..
-        } => {
-            format!(
-                "Scan completed: {} commits, {} files, {} ({}) at {}",
-                stats.total_commits,
-                stats.total_files_changed,
-                format_lines(stats.total_insertions, stats.total_deletions),
-                format_duration(stats.scan_duration),
-                format_timestamp(timestamp)
-            )
-        }
-        SM::ScanError {
-            error,
-            context,
-            timestamp,
-            ..
-        } => {
-            format!(
-                "Scan error at {}: {} (context: {})",
-                format_timestamp(timestamp),
-                error,
+                "{}{}:{}:{}:{}",
+                header_prefix,
+                paint(StyleRole::Header, "scan_error"),
+                paint(StyleRole::Key, scanner_id),
+                paint(StyleRole::Error, error),
                 context
             )
         }
-    };
-
-    if show_headers {
-        format!(
-            "[{}] {} from {}: {}",
-            typed_msg.header.sequence,
-            typed_msg.header.message_type,
-            typed_msg.header.producer_id,
-            content_text
-        )
-    } else {
-        content_text
     }
 }
 
@@ -389,9 +215,12 @@ pub fn format_pretty_text_typed(
     let kv = |k: &str, v: String| format!("{}={}", key(k), v);
     let kvs = |k: &str, v: &str| format!("{}={}", key(k), v);
     let header_prefix = if show_headers {
-        format!(
-            "#{}@{} ",
-            typed_msg.header.sequence, typed_msg.header.producer_id
+        paint(
+            StyleRole::Header,
+            &format!(
+                "#{}@{} ",
+                typed_msg.header.sequence, typed_msg.header.producer_id
+            ),
         )
     } else {
         String::new()
@@ -429,14 +258,14 @@ pub fn format_pretty_text_typed(
             };
             parts.push(kvs("lines", &lines));
             let duration_str = {
-                let total_millis = stats.scan_duration.as_millis();
-                let minutes = total_millis / 60_000;
-                let seconds = (total_millis % 60_000) / 1_000;
-                let millis = total_millis % 1_000;
+                let total_nanos = stats.scan_duration.as_nanos();
+                let minutes = total_nanos / 60_000_000_000;
+                let seconds = (total_nanos % 60_000_000_000) / 1_000_000_000;
+                let nanos = total_nanos % 1_000_000_000;
                 if minutes > 0 {
-                    format!("{}m{}.{}s", minutes, seconds, millis / 100)
+                    format!("{}m{}.{:06}s", minutes, seconds, nanos / 1000)
                 } else {
-                    format!("{}.{}s", seconds, millis / 100)
+                    format!("{}.{:06}s", seconds, nanos / 1000)
                 }
             };
             parts.push(kvs("duration", &duration_str));

--- a/src/plugin/builtin/dump/mod.rs
+++ b/src/plugin/builtin/dump/mod.rs
@@ -31,8 +31,6 @@ pub enum OutputFormat {
     Text,
     Json,
     Compact,
-    /// Raw legacy dump format (pre-RS-32). Not exposed via CLI flag (use config).
-    Raw,
 }
 
 impl std::fmt::Display for OutputFormat {
@@ -41,7 +39,6 @@ impl std::fmt::Display for OutputFormat {
             OutputFormat::Text => write!(f, "text"),
             OutputFormat::Json => write!(f, "json"),
             OutputFormat::Compact => write!(f, "compact"),
-            OutputFormat::Raw => write!(f, "raw"),
         }
     }
 }


### PR DESCRIPTION
- Standardizes color configuration across plugins by replacing optional color settings with a simple boolean flag.
- Removes the legacy "Raw" output format from the dump plugin, including related code paths and configuration options.
- Refactors argument parsing and plugin initialization to align with the new color configuration approach.
- Cleans up and simplifies related tests and internal APIs to reflect these changes.

## Summary by Sourcery

Simplify and unify color configuration and remove legacy raw output format across plugins

Enhancements:
- Use a single boolean flag for color settings in PluginConfig and propagate it throughout plugin initialization and argument parsing
- Refactor dump plugin formatting to use StyleRole-based coloring and update timestamp and duration formatting to nanosecond precision
- Streamline the plugin argument parser by removing optional color logic and dropping deprecated helper methods