### PR TITLE
refactor: store thread-safe gix repositories in scanner tasks

### DIFF
--- a/src/scanner/manager.rs
+++ b/src/scanner/manager.rs
@@ -694,7 +694,7 @@ impl ScannerManager {
                 }
 
                 // Cancel repository reservation if applicable
-                if let Ok(repo_id) = self.get_unique_repo_id(scanner.repository()) {
+                if let Ok(repo_id) = self.get_unique_repo_id(&scanner.repository()) {
                     self.cancel_reservation(&repo_id);
                 }
 

--- a/src/scanner/manager.rs
+++ b/src/scanner/manager.rs
@@ -694,7 +694,8 @@ impl ScannerManager {
                 }
 
                 // Cancel repository reservation if applicable
-                if let Ok(repo_id) = self.get_unique_repo_id(&scanner.repository()) {
+                let repo = scanner.repository();
+                if let Ok(repo_id) = self.get_unique_repo_id(&repo) {
                     self.cancel_reservation(&repo_id);
                 }
 

--- a/src/scanner/task/core.rs
+++ b/src/scanner/task/core.rs
@@ -211,6 +211,9 @@ impl ScannerTask {
     }
 
     /// Materialize a thread-local repository handle from the shared repository state.
+    ///
+    /// Callers should cache the returned handle in a local variable when they need
+    /// to perform multiple repository operations within the same function.
     pub fn repository(&self) -> gix::Repository {
         self.repository.to_thread_local()
     }

--- a/src/scanner/task/core.rs
+++ b/src/scanner/task/core.rs
@@ -19,7 +19,7 @@ pub struct ScannerTask {
     /// Repository path (local or remote URL - normalized)
     repository_path: String,
     /// Git repository instance
-    repository: gix::Repository,
+    repository: gix::ThreadSafeRepository,
     /// Flag indicating if this is a remote repository
     is_remote: bool,
     /// Combined requirements from all active plugins
@@ -57,22 +57,25 @@ impl std::fmt::Debug for ScannerTask {
 
 impl ScannerTask {
     /// Create a new ScannerTask with dependency injection
-    pub fn new(
+    pub fn new<R>(
         scanner_id: String,
         repository_path: String,
-        repository: gix::Repository,
+        repository: R,
         requirements: ScanRequires,
         queue_publisher: QueuePublisher,
         query_params: Option<QueryParams>,
         checkout_manager: Option<Arc<Mutex<crate::scanner::checkout::manager::CheckoutManager>>>,
         notification_manager: Arc<TokioMutex<AsyncNotificationManager>>,
-    ) -> Self {
+    ) -> Self
+    where
+        R: Into<gix::ThreadSafeRepository>,
+    {
         let is_remote = Self::is_remote_path(&repository_path);
 
         Self {
             scanner_id,
             repository_path,
-            repository,
+            repository: repository.into(),
             is_remote,
             requirements,
             query_params,
@@ -207,9 +210,9 @@ impl ScannerTask {
         &self.repository_path
     }
 
-    /// Get reference to the repository instance
-    pub fn repository(&self) -> &gix::Repository {
-        &self.repository
+    /// Materialize a thread-local repository handle from the shared repository state.
+    pub fn repository(&self) -> gix::Repository {
+        self.repository.to_thread_local()
     }
 
     /// Get the requirements for this scanner task

--- a/src/scanner/task/git_ops.rs
+++ b/src/scanner/task/git_ops.rs
@@ -204,7 +204,7 @@ impl ScannerTask {
         )
         .await?;
 
-        // Use the repository directly - it's already opened
+        // Materialize one thread-local repository handle for this scan operation.
         let repo = self.repository();
 
         // Start timing the actual scanning work
@@ -218,7 +218,7 @@ impl ScannerTask {
         // Create repository data for the message
         let mut builder = crate::scanner::types::RepositoryData::builder()
             .with_repository(self.repository_path())
-            .with_repository_info(repo);
+            .with_repository_info(&repo);
 
         if let Some(params) = query_params {
             builder = builder.with_query(params);
@@ -412,7 +412,7 @@ impl ScannerTask {
             // Calculate insertions/deletions by analyzing diff against first parent
             let (commit_insertions, commit_deletions) =
                 if let Some(first_parent_id) = commit.parent_ids().next() {
-                    match Self::parse_commit_diff(repo, &commit, first_parent_id.into()) {
+                    match Self::parse_commit_diff(&repo, &commit, first_parent_id.into()) {
                         Ok(diff_files) => {
                             // Aggregate insertions/deletions from all changed files
                             diff_files.iter().fold((0, 0), |(ins, del), file| {
@@ -1410,12 +1410,12 @@ impl ScannerTask {
         );
 
         // Parse the revision to get commit SHA
-        let parsed_ref =
-            self.repository()
-                .rev_parse(commit_sha)
-                .map_err(|e| ScanError::Repository {
-                    message: format!("Failed to resolve revision '{}': {}", commit_sha, e),
-                })?;
+        let repo = self.repository();
+        let parsed_ref = repo
+            .rev_parse(commit_sha)
+            .map_err(|e| ScanError::Repository {
+                message: format!("Failed to resolve revision '{}': {}", commit_sha, e),
+            })?;
 
         let commit_id = parsed_ref.single().ok_or_else(|| ScanError::Repository {
             message: format!(
@@ -1425,12 +1425,11 @@ impl ScannerTask {
         })?;
 
         // Get the commit object
-        let commit =
-            self.repository()
-                .find_commit(commit_id)
-                .map_err(|e| ScanError::Repository {
-                    message: format!("Failed to find commit '{}': {}", commit_id, e),
-                })?;
+        let commit = repo
+            .find_commit(commit_id)
+            .map_err(|e| ScanError::Repository {
+                message: format!("Failed to find commit '{}': {}", commit_id, e),
+            })?;
 
         // Get the tree from the commit
         let tree = commit.tree().map_err(|e| ScanError::Repository {
@@ -1438,11 +1437,11 @@ impl ScannerTask {
         })?;
 
         // Count total entries for progress reporting
-        let total_entries = self.count_tree_entries(&tree)?;
+        let total_entries = Self::count_tree_entries(&tree)?;
         let mut extracted_count = 0;
 
         // Extract all files recursively
-        self.extract_tree_recursive(
+        Self::extract_tree_recursive(
             &tree,
             target_dir,
             "",
@@ -1455,7 +1454,7 @@ impl ScannerTask {
     }
 
     /// Count total entries in a Git tree recursively
-    fn count_tree_entries(&self, tree: &gix::Tree) -> ScanResult<usize> {
+    fn count_tree_entries(tree: &gix::Tree) -> ScanResult<usize> {
         let mut count = 0;
         for entry_result in tree.iter() {
             let entry = entry_result.map_err(|e| ScanError::Repository {
@@ -1473,7 +1472,7 @@ impl ScannerTask {
                     .map_err(|_| ScanError::Repository {
                         message: "Expected tree object".to_string(),
                     })?;
-                count += self.count_tree_entries(&subtree)?;
+                count += Self::count_tree_entries(&subtree)?;
             } else {
                 count += 1;
             }
@@ -1483,7 +1482,6 @@ impl ScannerTask {
 
     /// Recursively extract tree contents to directory
     fn extract_tree_recursive(
-        &self,
         tree: &gix::Tree,
         base_dir: &std::path::Path,
         relative_path: &str,
@@ -1529,7 +1527,7 @@ impl ScannerTask {
                         message: "Expected tree object".to_string(),
                     })?;
 
-                self.extract_tree_recursive(
+                Self::extract_tree_recursive(
                     &subtree,
                     base_dir,
                     &entry_path,
@@ -1589,12 +1587,12 @@ impl ScannerTask {
         );
 
         // Use gix to resolve the revision to a commit object
-        let parsed_ref =
-            self.repository()
-                .rev_parse(revision_str)
-                .map_err(|e| ScanError::Repository {
-                    message: format!("Failed to resolve revision '{}': {}", revision_str, e),
-                })?;
+        let repo = self.repository();
+        let parsed_ref = repo
+            .rev_parse(revision_str)
+            .map_err(|e| ScanError::Repository {
+                message: format!("Failed to resolve revision '{}': {}", revision_str, e),
+            })?;
 
         let commit_id = parsed_ref.single().ok_or_else(|| ScanError::Repository {
             message: format!(
@@ -1604,15 +1602,14 @@ impl ScannerTask {
         })?;
 
         // Verify the resolved object is actually a commit
-        let commit =
-            self.repository()
-                .find_commit(commit_id)
-                .map_err(|e| ScanError::Repository {
-                    message: format!(
-                        "Revision '{}' (SHA: {}) is not a valid commit: {}",
-                        revision_str, commit_id, e
-                    ),
-                })?;
+        let commit = repo
+            .find_commit(commit_id)
+            .map_err(|e| ScanError::Repository {
+                message: format!(
+                    "Revision '{}' (SHA: {}) is not a valid commit: {}",
+                    revision_str, commit_id, e
+                ),
+            })?;
 
         let commit_sha = commit.id().to_string();
 


### PR DESCRIPTION
## Summary
- store `gix::ThreadSafeRepository` in `ScannerTask` shared state
- keep repository discovery/validation on thread-local `gix::Repository`
- materialize thread-local repositories at scanner git operation boundaries

## Why
This addresses the scanner-side `clippy::arc_with_non_send_sync` issue without replacing the `gix` stack or changing scanner behavior.

## Validation
- `cargo test -q`
- `cargo check` via pre-commit

## Follow-up
This PR intentionally does not address the remaining scanner clippy items:
- `too_many_arguments`
- `only_used_in_recursion`

## Summary by Sourcery

Refactor scanner tasks to hold a thread-safe Git repository handle while materializing thread-local repositories only at Git operation boundaries.

Enhancements:
- Store a gix::ThreadSafeRepository in ScannerTask shared state and derive thread-local repository handles on demand.
- Generalize ScannerTask construction to accept any repository type convertible into gix::ThreadSafeRepository.
- Simplify Git tree traversal helpers into static methods that operate on passed-in trees and paths.
- Adjust scanner manager and Git operation call sites to work with the new repository ownership and borrowing model.