### PR TITLE
refactor: introduce builder-based scanner task initialization

### DIFF
--- a/openspec/changes/refactor-gix-repository/design.md
+++ b/openspec/changes/refactor-gix-repository/design.md
@@ -96,8 +96,9 @@ Alternative considered:
 Rollback strategy:
 - Revert the storage type back to `gix::Repository` and restore the old accessor shape. This is low-risk because the change is concentrated in scanner internals.
 
-## Open Questions
+## Outcome Notes
 
-- Should `ScannerTask` expose a closure-based repository helper or a simpler “get thread-local repository” helper?
-- Should `ScannerManager::validate_repository()` continue returning a thread-local `gix::Repository`, or should it return a small validation result struct that includes both normalized path and repository information before conversion?
-- Are there any scanner-side call sites outside `git_ops.rs` that should be moved behind the same repository boundary helper for consistency?
+Implemented outcome:
+- `ScannerTask` now stores `gix::ThreadSafeRepository` and exposes a simpler thread-local repository accessor.
+- `ScannerManager::validate_repository()` continues returning a thread-local `gix::Repository`, with conversion happening at shared-state storage time.
+- Scanner git operation entry points and cleanup paths were moved behind the same repository materialization boundary.

--- a/openspec/changes/refactor-gix-repository/tasks.md
+++ b/openspec/changes/refactor-gix-repository/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Shared Repository Boundary
 
-- [ ] 1.1 Update `ScannerTask` to store `gix::ThreadSafeRepository` instead of `gix::Repository`.
-- [ ] 1.2 Update scanner constructors and test builders so shared scanner state converts repositories to `ThreadSafeRepository` at storage time.
-- [ ] 1.3 Update `ScannerManager::validate_repository()` and related setup paths to validate with a thread-local repository and convert only before storing shared state.
-- [ ] 1.4 Update repository-ID and validation helpers in `scanner/manager.rs` to work cleanly across the thread-local/shared repository boundary.
+- [x] 1.1 Update `ScannerTask` to store `gix::ThreadSafeRepository` instead of `gix::Repository`.
+- [x] 1.2 Update scanner constructors and test builders so shared scanner state converts repositories to `ThreadSafeRepository` at storage time.
+- [x] 1.3 Update `ScannerManager::validate_repository()` and related setup paths to validate with a thread-local repository and convert only before storing shared state.
+- [x] 1.4 Update repository-ID and validation helpers in `scanner/manager.rs` to work cleanly across the thread-local/shared repository boundary.
 
 ## 2. Scanner Execution Boundary
 
-- [ ] 2.1 Replace the current `ScannerTask::repository()` access pattern with a boundary helper or accessor that materializes a thread-local `gix::Repository`.
-- [ ] 2.2 Update `scanner/task/git_ops.rs` operation entry points to obtain a thread-local repository at method boundaries.
-- [ ] 2.3 Preserve existing lower-level git helper signatures on `&gix::Repository` wherever possible by passing the materialized thread-local repository through them.
-- [ ] 2.4 Review scanner code outside `git_ops.rs` for any remaining direct assumptions about a stored `&gix::Repository` and move them behind the same boundary.
+- [x] 2.1 Replace the current `ScannerTask::repository()` access pattern with a boundary helper or accessor that materializes a thread-local `gix::Repository`.
+- [x] 2.2 Update `scanner/task/git_ops.rs` operation entry points to obtain a thread-local repository at method boundaries.
+- [x] 2.3 Preserve existing lower-level git helper signatures on `&gix::Repository` wherever possible by passing the materialized thread-local repository through them.
+- [x] 2.4 Review scanner code outside `git_ops.rs` for any remaining direct assumptions about a stored `&gix::Repository` and move them behind the same boundary.
 
 ## 3. Validation
 
-- [ ] 3.1 Update scanner tests and helper construction paths to remain ergonomic with the new shared repository storage type.
-- [ ] 3.2 Run the scanner-focused test suite and `cargo nextest run --workspace` to confirm repository behavior is unchanged.
-- [ ] 3.3 Run clippy validation and verify the scanner-side `arc_with_non_send_sync` findings are resolved or reduced as expected.
+- [x] 3.1 Update scanner tests and helper construction paths to remain ergonomic with the new shared repository storage type.
+- [x] 3.2 Run the scanner-focused test suite and `cargo nextest run --workspace` to confirm repository behavior is unchanged.
+- [x] 3.3 Run clippy validation and verify the scanner-side `arc_with_non_send_sync` findings are resolved or reduced as expected.

--- a/openspec/changes/refactor-scannertask-init/design.md
+++ b/openspec/changes/refactor-scannertask-init/design.md
@@ -130,3 +130,12 @@ Alternative considered:
 
 Rollback strategy:
 - Restore the previous flat constructor signature. This is low-risk because the change is limited to scanner initialization paths.
+
+## Outcome Notes
+
+Implemented outcome:
+- `ScannerTask` now exposes a dedicated builder for required runtime dependencies.
+- Optional scanner state is configured with builder methods for requirements, query parameters, checkout manager, and notification manager override.
+- Builder `build()` resolves the notification manager from the global service when no override is provided.
+- Test ergonomics are preserved with a concise test-only builder wrapper that auto-creates a queue publisher.
+- The `ScannerTask::new(...)` arity issue was removed; broader clippy failures remain outside this initialization change.

--- a/openspec/changes/refactor-scannertask-init/tasks.md
+++ b/openspec/changes/refactor-scannertask-init/tasks.md
@@ -1,18 +1,18 @@
 ## 1. ScannerTask Initialization API
 
-- [ ] 1.1 Replace the current flat `ScannerTask::new(...)` API with a dedicated builder whose required inputs are `scanner_id`, `repository_path`, `repository`, and `queue_publisher`.
-- [ ] 1.2 Add builder configuration methods for optional scanner state including `requirements`, `query_params`, `checkout_manager`, and notification manager override.
-- [ ] 1.3 Implement `ScanRequires::NONE` as the default builder value for requirements.
-- [ ] 1.4 Resolve notification manager defaulting in `build()` so runtime code uses the global notification service unless an override is supplied.
+- [x] 1.1 Replace the current flat `ScannerTask::new(...)` API with a dedicated builder whose required inputs are `scanner_id`, `repository_path`, `repository`, and `queue_publisher`.
+- [x] 1.2 Add builder configuration methods for optional scanner state including `requirements`, `query_params`, `checkout_manager`, and notification manager override.
+- [x] 1.3 Implement `ScanRequires::NONE` as the default builder value for requirements.
+- [x] 1.4 Resolve notification manager defaulting in `build()` so runtime code uses the global notification service unless an override is supplied.
 
 ## 2. Scanner Construction Call Sites
 
-- [ ] 2.1 Update `ScannerManager` task creation to use the builder-based scanner initialization API.
-- [ ] 2.2 Update test builders and helper construction paths to remain concise with the new initialization flow.
-- [ ] 2.3 Review scanner call sites to ensure checkout support is only supplied through the optional configuration path when required.
+- [x] 2.1 Update `ScannerManager` task creation to use the builder-based scanner initialization API.
+- [x] 2.2 Update test builders and helper construction paths to remain concise with the new initialization flow.
+- [x] 2.3 Review scanner call sites to ensure checkout support is only supplied through the optional configuration path when required.
 
 ## 3. Validation
 
-- [ ] 3.1 Run scanner tests to confirm normal scan publishing behavior still requires and uses `QueuePublisher`.
-- [ ] 3.2 Run `cargo nextest run --workspace` to confirm scanner initialization behavior is unchanged.
-- [ ] 3.3 Run clippy validation and verify the `ScannerTask::new(...)` arity issue is resolved.
+- [x] 3.1 Run scanner tests to confirm normal scan publishing behavior still requires and uses `QueuePublisher`.
+- [x] 3.2 Run `cargo nextest run --workspace` to confirm scanner initialization behavior is unchanged.
+- [x] 3.3 Run clippy validation and verify the `ScannerTask::new(...)` arity issue is resolved.

--- a/src/scanner/manager.rs
+++ b/src/scanner/manager.rs
@@ -561,20 +561,18 @@ impl ScannerManager {
                 }
             })?;
 
-        // Create independent notification manager for scanner dependency injection
-        let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
-
-        // Create scanner task with simple dependency injection
-        let scanner_task = ScannerTask::new(
+        // Create scanner task with builder-based dependency injection
+        let scanner_task = ScannerTask::builder(
             scanner_id.clone(),
             normalised_path.clone(),
             repo,
-            requirements,
             queue_publisher,
-            query_params.cloned(),
-            checkout_manager,
-            notification_manager,
-        );
+        )
+        .with_requirements(requirements)
+        .with_query_params(query_params.cloned())
+        .with_checkout_manager(checkout_manager)
+        .with_notification_manager(Arc::new(TokioMutex::new(AsyncNotificationManager::new())))
+        .build();
         let scanner_task = Arc::new(scanner_task);
 
         // Store the scanner task in the manager for later use

--- a/src/scanner/task/core.rs
+++ b/src/scanner/task/core.rs
@@ -110,7 +110,10 @@ impl ScannerTask {
             .create_publisher(scanner_id.clone())
             .expect("Failed to create test queue publisher");
 
+        let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
+
         Self::builder(scanner_id, repository_path, repository, test_publisher)
+            .with_notification_manager(notification_manager)
     }
 }
 
@@ -166,13 +169,7 @@ impl ScannerTask {
         repository_path: String,
         repository: gix::Repository,
     ) -> Self {
-        // Create a test queue publisher and notification manager for test scenarios
-        let queue_service = crate::queue::api::get_queue_service();
-        let test_publisher = queue_service
-            .create_publisher(scanner_id.clone())
-            .expect("Failed to create test queue publisher");
-
-        Self::builder(scanner_id, repository_path, repository, test_publisher).build()
+        Self::builder_for_tests(scanner_id, repository_path, repository).build()
     }
 
     /// Determine if a repository path represents a remote repository

--- a/src/scanner/task/core.rs
+++ b/src/scanner/task/core.rs
@@ -3,7 +3,7 @@
 //! Core ScannerTask struct and basic methods including constructors and accessors.
 
 use crate::core::query::QueryParams;
-use crate::notifications::api::AsyncNotificationManager;
+use crate::notifications::api::{get_notification_service_arc, AsyncNotificationManager};
 use crate::queue::api::QueuePublisher;
 use crate::scanner::types::ScanRequires;
 use std::sync::{Arc, Mutex};
@@ -56,90 +56,105 @@ impl std::fmt::Debug for ScannerTask {
 }
 
 impl ScannerTask {
-    /// Create a new ScannerTask with dependency injection
-    pub fn new<R>(
+    /// Create a new `ScannerTask` builder with the required runtime dependencies.
+    pub fn builder<R>(
         scanner_id: String,
         repository_path: String,
         repository: R,
-        requirements: ScanRequires,
         queue_publisher: QueuePublisher,
-        query_params: Option<QueryParams>,
-        checkout_manager: Option<Arc<Mutex<crate::scanner::checkout::manager::CheckoutManager>>>,
-        notification_manager: Arc<TokioMutex<AsyncNotificationManager>>,
-    ) -> Self
+    ) -> ScannerTaskBuilder
     where
         R: Into<gix::ThreadSafeRepository>,
     {
-        let is_remote = Self::is_remote_path(&repository_path);
-
-        Self {
+        ScannerTaskBuilder {
             scanner_id,
             repository_path,
             repository: repository.into(),
-            is_remote,
-            requirements,
-            query_params,
-            checkout_manager,
+            requirements: ScanRequires::NONE,
+            query_params: None,
+            checkout_manager: None,
             queue_publisher,
-            notification_manager,
+            notification_manager: None,
+        }
+    }
+
+    fn from_builder(builder: ScannerTaskBuilder) -> Self {
+        let is_remote = Self::is_remote_path(&builder.repository_path);
+
+        Self {
+            scanner_id: builder.scanner_id,
+            repository_path: builder.repository_path,
+            repository: builder.repository,
+            is_remote,
+            requirements: builder.requirements,
+            query_params: builder.query_params,
+            checkout_manager: builder.checkout_manager,
+            queue_publisher: builder.queue_publisher,
+            notification_manager: builder
+                .notification_manager
+                .unwrap_or_else(get_notification_service_arc),
             checkout_root: Mutex::new(None),
             seen_checkout_files: Mutex::new(std::collections::HashSet::new()),
         }
     }
 
-    /// Create a simple builder for backward compatibility with tests
-    /// This is deprecated in favor of direct constructor injection
+    /// Create a concise test-only builder that auto-creates a queue publisher.
     #[cfg(test)]
-    pub fn builder(
+    pub fn builder_for_tests(
         scanner_id: String,
         repository_path: String,
         repository: gix::Repository,
-    ) -> TestScannerTaskBuilder {
-        TestScannerTaskBuilder {
-            scanner_id,
-            repository_path,
-            repository,
-            requirements: ScanRequires::NONE,
-        }
+    ) -> ScannerTaskBuilder {
+        let queue_service = crate::queue::api::get_queue_service();
+        let test_publisher = queue_service
+            .create_publisher(scanner_id.clone())
+            .expect("Failed to create test queue publisher");
+
+        Self::builder(scanner_id, repository_path, repository, test_publisher)
     }
 }
 
-/// Simplified builder for test compatibility only
-/// Production code should use ScannerTask::new() directly
-#[cfg(test)]
-pub struct TestScannerTaskBuilder {
+/// Builder for constructing a fully initialized `ScannerTask`.
+pub struct ScannerTaskBuilder {
     scanner_id: String,
     repository_path: String,
-    repository: gix::Repository,
+    repository: gix::ThreadSafeRepository,
     requirements: ScanRequires,
+    query_params: Option<QueryParams>,
+    checkout_manager: Option<Arc<Mutex<crate::scanner::checkout::manager::CheckoutManager>>>,
+    queue_publisher: QueuePublisher,
+    notification_manager: Option<Arc<TokioMutex<AsyncNotificationManager>>>,
 }
 
-#[cfg(test)]
-impl TestScannerTaskBuilder {
+impl ScannerTaskBuilder {
     pub fn with_requirements(mut self, requirements: ScanRequires) -> Self {
         self.requirements = requirements;
         self
     }
 
-    pub fn build(self) -> ScannerTask {
-        // Create test queue publisher and notification manager automatically
-        let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
-        // Create test queue publisher automatically
-        let queue_service = crate::queue::api::get_queue_service();
-        let test_publisher = queue_service
-            .create_publisher(self.scanner_id.clone())
-            .expect("Failed to create test queue publisher");
+    pub fn with_query_params(mut self, query_params: Option<QueryParams>) -> Self {
+        self.query_params = query_params;
+        self
+    }
 
-        ScannerTask::new(
-            self.scanner_id,
-            self.repository_path,
-            self.repository,
-            self.requirements,
-            test_publisher,
-            None,
-            None,
-            notification_manager,
-        )
+    pub fn with_checkout_manager(
+        mut self,
+        checkout_manager: Option<Arc<Mutex<crate::scanner::checkout::manager::CheckoutManager>>>,
+    ) -> Self {
+        self.checkout_manager = checkout_manager;
+        self
+    }
+
+    pub fn with_notification_manager(
+        mut self,
+        notification_manager: Arc<TokioMutex<AsyncNotificationManager>>,
+    ) -> Self {
+        self.notification_manager = Some(notification_manager);
+        self
+    }
+
+    pub fn build(self) -> ScannerTask {
+        ScannerTask::from_builder(self)
     }
 }
 
@@ -157,18 +172,7 @@ impl ScannerTask {
             .create_publisher(scanner_id.clone())
             .expect("Failed to create test queue publisher");
 
-        let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
-
-        Self::new(
-            scanner_id,
-            repository_path,
-            repository,
-            ScanRequires::NONE,
-            test_publisher,
-            None,
-            None,
-            notification_manager,
-        )
+        Self::builder(scanner_id, repository_path, repository, test_publisher).build()
     }
 
     /// Determine if a repository path represents a remote repository

--- a/src/scanner/task/tests/author_filtering.rs
+++ b/src/scanner/task/tests/author_filtering.rs
@@ -94,7 +94,7 @@ async fn test_commit_traversal_with_author_filtering() {
     );
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo,
@@ -215,7 +215,7 @@ async fn test_complex_wildcard_patterns() {
     }
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo,
@@ -317,7 +317,7 @@ async fn test_email_auto_completion_integration() {
     }
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo,

--- a/src/scanner/task/tests/commit_traversal.rs
+++ b/src/scanner/task/tests/commit_traversal.rs
@@ -31,7 +31,7 @@ async fn test_commit_traversal_with_max_commits() {
     }
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -115,7 +115,7 @@ async fn test_commit_traversal_with_git_ref() {
     }
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -207,7 +207,7 @@ async fn test_commit_traversal_ordering() {
     }
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -278,7 +278,7 @@ async fn test_empty_repository_traversal() {
 
     // Don't create any commits - leave repository empty
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,

--- a/src/scanner/task/tests/diff_analysis.rs
+++ b/src/scanner/task/tests/diff_analysis.rs
@@ -33,7 +33,7 @@ async fn test_real_commit_diff_analysis() {
     commit_all(repo_path, "Add initial project files");
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -111,7 +111,7 @@ async fn test_commit_diff_statistics() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo_clone,
@@ -186,7 +186,7 @@ async fn test_file_change_types() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -251,7 +251,7 @@ async fn test_file_paths_for_renames() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -331,7 +331,7 @@ async fn test_line_level_statistics_per_file() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -410,7 +410,7 @@ async fn test_binary_vs_text_file_detection() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -502,7 +502,7 @@ async fn test_comprehensive_change_type_coverage() {
     commit_all(repo_path, "Initial commit");
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo.clone(),
@@ -630,7 +630,7 @@ async fn test_real_file_paths_not_placeholder() {
 
     let repo = gix::open(repo_path).unwrap();
     let repo_clone = repo.clone();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,

--- a/src/scanner/task/tests/file_extraction.rs
+++ b/src/scanner/task/tests/file_extraction.rs
@@ -47,7 +47,7 @@ async fn test_extract_commit_files_to_directory() {
 
     // Create ScannerTask
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -199,7 +199,7 @@ async fn test_extract_files_creates_full_checkout_paths() {
 
     // Create ScannerTask and extract files
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -270,7 +270,7 @@ async fn test_resolve_revision_method() {
 
     // Create ScannerTask
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,

--- a/src/scanner/task/tests/git_reference_resolution.rs
+++ b/src/scanner/task/tests/git_reference_resolution.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 async fn test_enhanced_git_reference_resolution() {
     let (_temp_dir, repo) = create_test_repository();
 
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo.clone(),
@@ -67,7 +67,7 @@ async fn test_enhanced_git_reference_resolution() {
 async fn test_git_reference_validation() {
     let (_temp_dir, repo) = create_test_repository();
 
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo,
@@ -180,7 +180,7 @@ async fn test_complex_git_reference_patterns() {
         .unwrap();
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo.path().to_string_lossy().to_string(),
         repo,

--- a/src/scanner/task/tests/helpers.rs
+++ b/src/scanner/task/tests/helpers.rs
@@ -4,13 +4,10 @@
 
 use super::super::*;
 // Removed unused imports: QueryParams, collect_scan_messages, count_commit_messages
-use crate::notifications::api::AsyncNotificationManager;
 use crate::scanner::types::ScanRequires;
 use std::path::Path;
 use std::process::Command;
-use std::sync::Arc;
 use tempfile::TempDir;
-use tokio::sync::Mutex as TokioMutex;
 
 /// Run a git command in a test repository and assert that it succeeds.
 pub fn run_git(repo_path: &Path, args: &[&str]) {
@@ -60,23 +57,9 @@ pub fn create_test_scanner_task(requirements: ScanRequires) -> (TempDir, Scanner
     let (_temp_dir, repo) = create_test_repo();
     let repo_path = repo.git_dir().to_string_lossy().to_string();
 
-    // Create test queue publisher and notification manager
-    let queue_service = crate::queue::api::get_queue_service();
-    let test_publisher = queue_service
-        .create_publisher("test-scanner-123".to_string())
-        .expect("Failed to create test queue publisher");
-
-    let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
-
-    let scanner = ScannerTask::builder(
-        "test-scanner-123".to_string(),
-        repo_path,
-        repo,
-        test_publisher,
-    )
-    .with_requirements(requirements)
-    .with_notification_manager(notification_manager)
-    .build();
+    let scanner = ScannerTask::builder_for_tests("test-scanner-123".to_string(), repo_path, repo)
+        .with_requirements(requirements)
+        .build();
     (_temp_dir, scanner)
 }
 

--- a/src/scanner/task/tests/helpers.rs
+++ b/src/scanner/task/tests/helpers.rs
@@ -68,16 +68,15 @@ pub fn create_test_scanner_task(requirements: ScanRequires) -> (TempDir, Scanner
 
     let notification_manager = Arc::new(TokioMutex::new(AsyncNotificationManager::new()));
 
-    let scanner = ScannerTask::new(
+    let scanner = ScannerTask::builder(
         "test-scanner-123".to_string(),
         repo_path,
         repo,
-        requirements,
         test_publisher,
-        None,
-        None,
-        notification_manager,
-    );
+    )
+    .with_requirements(requirements)
+    .with_notification_manager(notification_manager)
+    .build();
     (_temp_dir, scanner)
 }
 

--- a/src/scanner/task/tests/scan_statistics.rs
+++ b/src/scanner/task/tests/scan_statistics.rs
@@ -22,7 +22,7 @@ async fn test_scan_statistics_timing_measurement() {
     commit_all(repo_path, "Test commit");
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -94,7 +94,7 @@ async fn test_scan_statistics_file_totals() {
     commit_all(repo_path, "Add another file");
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,
@@ -156,7 +156,7 @@ async fn test_scan_statistics_empty_repository() {
     init_test_git_repo(repo_path);
 
     let repo = gix::open(repo_path).unwrap();
-    let scanner_task = ScannerTask::builder(
+    let scanner_task = ScannerTask::builder_for_tests(
         "test-scanner".to_string(),
         repo_path.to_string_lossy().to_string(),
         repo,

--- a/src/scanner/tests/manager.rs
+++ b/src/scanner/tests/manager.rs
@@ -394,16 +394,15 @@ async fn test_commit_traversal_and_message_creation() {
             crate::notifications::api::AsyncNotificationManager::new(),
         ));
 
-        crate::scanner::task::ScannerTask::new(
+        crate::scanner::task::ScannerTask::builder(
             scanner_id,
             current_path.to_string(),
             repo,
-            ScanRequires::COMMITS | ScanRequires::FILE_CHANGES,
             test_publisher,
-            None,
-            None,
-            notification_manager,
         )
+        .with_requirements(ScanRequires::COMMITS | ScanRequires::FILE_CHANGES)
+        .with_notification_manager(notification_manager)
+        .build()
     };
 
     // Scan commits and capture messages for testing

--- a/tests/scanner/messaging.rs
+++ b/tests/scanner/messaging.rs
@@ -132,16 +132,18 @@ async fn test_commit_traversal_and_message_creation() {
             repostats::notifications::api::AsyncNotificationManager::new(),
         ));
 
-        repostats::scanner::api::ScannerTask::new(
+        repostats::scanner::api::ScannerTask::builder(
             scanner_id,
             current_path.to_string(),
             repo,
-            repostats::scanner::api::ScanRequires::COMMITS | repostats::scanner::api::ScanRequires::FILE_CHANGES,
             test_publisher,
-            None,
-            None,
-            notification_manager,
         )
+        .with_requirements(
+            repostats::scanner::api::ScanRequires::COMMITS
+                | repostats::scanner::api::ScanRequires::FILE_CHANGES,
+        )
+        .with_notification_manager(notification_manager)
+        .build()
     };
 
     // Scan commits and capture messages for testing

--- a/tests/scanner/tasks.rs
+++ b/tests/scanner/tasks.rs
@@ -221,16 +221,10 @@ async fn test_comprehensive_scanner_task_creation() {
             repostats::notifications::api::AsyncNotificationManager::new(),
         ));
 
-        ScannerTask::new(
-            scanner_id,
-            current_path.to_string(),
-            repo,
-            ScanRequires::COMMITS | ScanRequires::FILE_CHANGES,
-            test_publisher,
-            None,
-            None,
-            notification_manager,
-        )
+        ScannerTask::builder(scanner_id, current_path.to_string(), repo, test_publisher)
+            .with_requirements(ScanRequires::COMMITS | ScanRequires::FILE_CHANGES)
+            .with_notification_manager(notification_manager)
+            .build()
     };
 
     // Verify scanner task properties


### PR DESCRIPTION
## Summary
- replace the flat `ScannerTask` constructor with a required-input builder
- move optional scanner state behind builder methods with defaults
- preserve concise scanner test construction with a test-only compatibility builder

## Why
This addresses the scanner-side constructor arity issue by separating required runtime dependencies from optional configuration while keeping scanner queue publishing explicit.

## Validation
- cargo check
- cargo nextest run --workspace

## OpenSpec
- sync refactor-gix-repository artifacts to the merged implementation outcome
- implement and sync refactor-scannertask-init

## Follow-up
This PR does not address the remaining broader clippy warning set outside scanner initialization.

## Summary by Sourcery

Introduce a builder-based API for ScannerTask initialization and update call sites to separate required scanner dependencies from optional configuration while preserving test ergonomics and repository boundary behavior.

New Features:
- Add ScannerTaskBuilder for constructing ScannerTask instances with explicit required runtime dependencies and optional configuration.
- Expose a concise test-only ScannerTask::builder_for_tests helper that auto-creates a queue publisher for scanner tests.

Enhancements:
- Default ScannerTask builder requirements to ScanRequires::NONE and derive the notification manager from the global service when not overridden.
- Refine scanner manager task creation to use the new builder-based initialization API instead of the flat constructor.
- Document the implemented outcomes for the gix repository refactor and scanner task initialization in the OpenSpec files, marking associated tasks as completed.

Tests:
- Update scanner and messaging tests to use the new ScannerTask builder and test helper while keeping task construction concise.