### PR TITLE
chore: upgrade toolchain and dependency baseline

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: rust
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,6 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # Keep the explicit stable lane in sync with rust-toolchain.toml.
         rust: ["1.90.0", beta]
         # Optional: exclude problematic combinations
         exclude:
@@ -54,7 +55,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy, rust-src
+          components: rustfmt, clippy
 
       - name: Configure Cargo cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,9 +45,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          components: rustfmt, clippy
+        run: |
+          rustup show active-toolchain
+          rustup component add rustfmt clippy
 
       - name: Configure Cargo cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta]
+        rust: ["1.90.0", beta]
         # Optional: exclude problematic combinations
         exclude:
           # Beta on Windows can be flaky, exclude for now

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   # Step 1.3: Cross-platform validation with matrix strategy
   validate:
-    name: Validate (${{ matrix.os }}, ${{ matrix.rust }})
+    name: Validate (${{ matrix.os }}, stable)
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -37,13 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Keep the explicit stable lane in sync with rust-toolchain.toml.
-        rust: ["1.90.0", beta]
-        # Optional: exclude problematic combinations
-        exclude:
-          # Beta on Windows can be flaky, exclude for now
-          - os: windows-latest
-            rust: beta
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -54,14 +47,13 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Configure Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
           # Cache key includes OS, Rust version, and dependencies
-          key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('Cargo.toml', 'rust-toolchain.toml') }}
           # Save cache even on failure to speed up subsequent runs
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -70,7 +62,7 @@ jobs:
 
       - name: Verify toolchain setup
         run: |
-          echo "Rust toolchain setup completed for ${{ matrix.os }} with ${{ matrix.rust }}"
+          echo "Rust toolchain setup completed for ${{ matrix.os }} with the pinned stable toolchain"
           rustc --version
           cargo --version
           rustfmt --version
@@ -83,4 +75,47 @@ jobs:
           cargo check --bins --tests --verbose
         env:
           # Allow warnings in basic validation - detailed linting will be in step 1.4
+          RUSTFLAGS: "-A warnings"
+
+  validate-beta:
+    name: Validate (${{ matrix.os }}, beta)
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: beta
+          components: rustfmt, clippy
+
+      - name: Configure Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-beta-cargo-${{ hashFiles('Cargo.toml', 'rust-toolchain.toml') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Verify toolchain setup
+        run: |
+          echo "Rust toolchain setup completed for ${{ matrix.os }} with beta"
+          rustc --version
+          cargo --version
+          rustfmt --version
+          cargo clippy --version
+
+      - name: Basic build validation
+        run: |
+          echo "Running basic build validation across beta canary..."
+          cargo check --bins --tests --verbose
+        env:
           RUSTFLAGS: "-A warnings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ dashmap = "6.1.0"
 dirs = "6.0"
 flexi_logger = "0.31"
 futures = "0.3"
-gix = { version = "0.73", features = ["blocking-network-client"] }
-gix-object = "0.50"
-gix-protocol = "0.51"
+gix = { version = "0.74", features = ["blocking-network-client"] }
+gix-object = "0.51"
+gix-protocol = "0.52"
 gix-transport = { version = "0.48.0", features = ["blocking-client", "http-client-reqwest-rust-tls"] }
-gix-url = "0.32.0"
+gix-url = "0.33.1"
 glob = "0.3"
 inventory = "0.3"
 libc = "0.2"
@@ -41,7 +41,7 @@ once_cell = "1.20"
 prettytable-rs = "0.10"
 rand = "0.8.5"
 regex = "1"
-reqwest = { version = "0.11", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9.34"

--- a/openspec/changes/upgrade-toolchain-and-dependencies/design.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The merged `introduce-service-facades` work restored a clean local and CI baseline, but it also exposed a practical problem: dependency behavior is not as predictable across environments as the repository should tolerate.
+
+The PR required a follow-up fix in `src/core/styles.rs` because CI resolved a `colored` version with a different enum shape than the local environment. That is exactly the kind of drift that becomes more common when:
+
+- the Rust toolchain baseline is implicit rather than intentional
+- dependencies are updated opportunistically instead of in controlled batches
+- local and CI resolution behavior diverge over time
+
+Now that `main` is again green on `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`, the repository has a good point-in-time baseline for a deliberate refresh. The goal is not “latest at all costs.” The goal is a supported toolchain and dependency set that the project understands, validates, and can keep green.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- define an explicit Rust toolchain baseline for the project
+- refresh dependencies in a controlled, reviewable sequence
+- reduce surprises caused by local/CI version skew
+- keep test, lint, and CI baselines green throughout the refresh
+- document the resulting toolchain and dependency policy so later upgrades are less ad hoc
+
+**Non-Goals:**
+
+- bundling unrelated architecture changes into the upgrade work
+- rewriting subsystems merely because newer crates make that possible
+- chasing every newest release immediately if it adds churn without value
+- replacing core libraries unless the refresh exposes a concrete reason
+
+## Decisions
+
+### Decision: Upgrade in bounded slices, not one large unstructured jump
+
+The refresh should proceed in ordered slices:
+
+1. define and apply the intended Rust toolchain baseline
+2. review and update direct dependencies deliberately
+3. let transitive dependency updates follow from the direct set
+4. repair breakage, lint fallout, and CI drift before widening scope further
+
+Rationale:
+
+- this keeps failures attributable
+- it makes rollback practical
+- it prevents a single large dependency graph churn from obscuring the real sources of breakage
+
+Alternatives considered:
+
+- run a blanket dependency update and repair everything afterward
+  - rejected because it produces poor blameability and high review noise
+
+### Decision: Treat local and CI resolution parity as a design requirement
+
+The refresh should make the project less sensitive to environment-specific resolution differences. That does not require perfectly identical environments, but it does require that the project understand and intentionally manage the versions it relies on.
+
+In practice, this means:
+
+- review whether the repository should pin or constrain some dependencies more explicitly
+- ensure CI and local validation both exercise the intended baseline
+- avoid code that compiles only because of an incidental local crate version
+
+Rationale:
+
+- the `colored` discrepancy already demonstrated that “works locally” is not sufficient
+- predictable resolution behavior improves trust in the validation pipeline
+
+Alternatives considered:
+
+- accept occasional local/CI differences as normal and fix them ad hoc
+  - rejected because it turns routine maintenance into recurring incident response
+
+### Decision: Toolchain policy should be explicit after the refresh
+
+The repository should end this change with a clearly documented Rust baseline and a matching CI posture.
+
+That may include:
+
+- a `rust-toolchain.toml` or equivalent explicit version policy
+- workflow/tooling updates that use the same baseline intentionally
+- documentation in project artifacts if the baseline changed materially
+
+Rationale:
+
+- implicit toolchain drift is hard to reason about
+- a stated baseline makes later upgrades intentional instead of accidental
+
+Alternatives considered:
+
+- continue relying on whichever stable toolchain happens to be installed locally or in CI
+  - rejected because it weakens reproducibility
+
+### Decision: Validation gates must stay green during the upgrade
+
+This change should preserve:
+
+- `cargo test`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- the existing PR workflow matrix
+
+If `nextest` or local pre-commit alignment also needs adjustment as part of the refresh, that should be coordinated with the existing validation-alignment work rather than lost inside dependency churn.
+
+Rationale:
+
+- a clean baseline is the main asset this change begins with
+- upgrades are only useful if the project can verify them consistently
+
+## Risks / Trade-offs
+
+- [Upgrading Rust increases lint or type-system strictness unexpectedly] -> do the toolchain baseline first and fix compiler/lint fallout before broad dependency churn.
+- [Dependency updates trigger many small API breakages at once] -> prefer direct-dependency slices and validate after each slice.
+- [A newer version is “available” but not worth the churn] -> optimize for supported and stable, not merely newest.
+- [Refresh work overlaps with validation-alignment work] -> coordinate changes to CI/pre-commit intentionally rather than letting dependency fallout redefine validation policy implicitly.
+
+## Migration Plan
+
+1. Inventory the current toolchain and direct dependency set.
+2. Decide the intended Rust baseline and apply it explicitly.
+3. Update direct dependencies in bounded groups, validating after each group.
+4. Fix API, lint, and test fallout.
+5. Confirm the PR workflow matrix is green with the refreshed baseline.
+6. Document the resulting baseline and any policy updates.
+
+Rollback strategy:
+
+- if a dependency or toolchain bump proves too disruptive, revert that bounded slice while retaining any independently safe fixes from earlier slices

--- a/openspec/changes/upgrade-toolchain-and-dependencies/proposal.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/proposal.md
@@ -23,5 +23,5 @@ The repository now has a clean `cargo test` and `cargo clippy --all-targets --al
 
 ## Impact
 
-- Affected code: `Cargo.toml`, `Cargo.lock`, any source or test files affected by upgraded crate APIs or lint behavior, CI workflow/toolchain configuration, and local developer tooling configuration.
+- Affected code: `Cargo.toml` dependency constraints, any source or test files affected by upgraded crate APIs or lint behavior, CI workflow/toolchain configuration, and local developer tooling configuration. Because this repository does not currently track `Cargo.lock`, dependency resolution changes are expected to come from manifest constraints unless the lockfile policy changes.
 - Affected systems: Rust compiler baseline, dependency resolution, local validation, CI matrix behavior, linting, and test execution.

--- a/openspec/changes/upgrade-toolchain-and-dependencies/proposal.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The recently merged service-facades work exposed version skew between local development and CI, especially around dependency behavior that differed under the PR matrix. The PR is now green, but it also showed that `repostats` is carrying toolchain and dependency drift that should be corrected deliberately rather than waiting for the next surprise break.
+
+The repository now has a clean `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` baseline on `main`, which makes this the right time to refresh Rust and dependencies in a controlled way.
+
+## What Changes
+
+- Review the current Rust toolchain version and decide whether to raise the project baseline.
+- Update Rust dependencies deliberately, prioritizing direct dependencies first and then validating the transitive fallout.
+- Align local and CI dependency resolution behavior as much as practical so version-specific surprises are reduced.
+- Fix any compile, lint, formatting, or test regressions introduced by the newer toolchain or dependency set.
+- Document the new toolchain/dependency baseline once the upgrade is stable.
+
+## Capabilities
+
+### New Capabilities
+- `toolchain-refresh`: Define and maintain a current supported Rust/tooling baseline for `repostats`.
+- `dependency-refresh`: Define the controlled upgrade path for crate dependencies while preserving a green baseline.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `Cargo.toml`, `Cargo.lock`, any source or test files affected by upgraded crate APIs or lint behavior, CI workflow/toolchain configuration, and local developer tooling configuration.
+- Affected systems: Rust compiler baseline, dependency resolution, local validation, CI matrix behavior, linting, and test execution.

--- a/openspec/changes/upgrade-toolchain-and-dependencies/specs/toolchain-refresh/spec.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/specs/toolchain-refresh/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Rust toolchain baseline must be explicit
+The repository SHALL define and use an intentional Rust toolchain baseline rather than relying on implicit local or CI defaults.
+
+#### Scenario: Toolchain baseline is reviewed and updated
+- **WHEN** the repository performs a toolchain refresh
+- **THEN** the project MUST explicitly select the supported Rust baseline
+- **AND** local and CI validation MUST target that baseline intentionally
+
+#### Scenario: Toolchain change introduces compile or lint fallout
+- **WHEN** a newer Rust baseline changes compiler or lint behavior
+- **THEN** the refresh MUST resolve the fallout or defer the baseline increase explicitly
+- **AND** the project MUST NOT leave the baseline ambiguous
+
+### Requirement: Dependency upgrades must be deliberate and reviewable
+The repository SHALL update dependencies in controlled slices that keep breakage attributable and reversible.
+
+#### Scenario: Direct dependencies are refreshed
+- **WHEN** dependencies are upgraded
+- **THEN** direct dependencies SHOULD be reviewed and updated intentionally before relying on transitive churn alone
+- **AND** the change SHOULD preserve a clear explanation of what was upgraded and why
+
+#### Scenario: Upgrade causes regressions
+- **WHEN** a dependency upgrade introduces API, behavior, lint, or test regressions
+- **THEN** the refresh MUST either repair the regressions or narrow/revert the problematic upgrade slice
+
+### Requirement: Local and CI dependency behavior must stay aligned enough for reliable validation
+The repository SHALL reduce avoidable local-versus-CI dependency and toolchain surprises.
+
+#### Scenario: CI exposes version-skew breakage
+- **WHEN** CI resolves dependency or toolchain behavior differently from local development
+- **THEN** the refresh MUST treat that as a configuration and validation problem to address
+- **AND** the repository SHOULD make the baseline more explicit so the difference does not recur silently
+
+#### Scenario: Refreshed baseline is accepted
+- **WHEN** the toolchain and dependency refresh is complete
+- **THEN** the resulting baseline MUST be validated in both local and CI-facing workflows
+- **AND** the project MUST preserve a green `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` baseline

--- a/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
@@ -41,7 +41,7 @@
   - keep `beta` in the matrix as the forward-compatibility canary
 - Toolchain fallout repaired:
   - the repository initially inherited the local `rustup` `complete` profile, which tried to install unavailable optional components for pinned `1.90.0`
-  - `rust-toolchain.toml` now sets `profile = "minimal"` and explicitly requests only `rustfmt`, `clippy`, and `rust-src`
+  - `rust-toolchain.toml` now sets `profile = "minimal"` and explicitly requests only `rustfmt` and `clippy`
   - after that change, `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` both passed under the pinned toolchain
 - First dependency slice completed:
   - direct dependencies were reviewed and the highest-value slice identified as HTTP/TLS alignment

--- a/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
@@ -37,7 +37,7 @@
   - dependency duplicates currently include overlapping HTTP/TLS stacks such as `reqwest 0.11/0.12`, `hyper 0.14/1.x`, and `rustls 0.21/0.23`
 - First implementation slice chosen:
   - explicitly pin the repository Rust baseline to `1.90.0`
-  - change the CI stable lane from floating `stable` to explicit `1.90.0`
+  - change the CI stable lane from floating `stable` to the repository-pinned baseline from `rust-toolchain.toml`
   - keep `beta` in the matrix as the forward-compatibility canary
 - Toolchain fallout repaired:
   - the repository initially inherited the local `rustup` `complete` profile, which tried to install unavailable optional components for pinned `1.90.0`
@@ -54,7 +54,7 @@
   - no source changes were required; `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` remained green after the refresh
 - Workflow compatibility spot-check completed:
   - local `cargo +beta check --bins --tests --verbose` completed successfully, matching the command shape used in the PR workflow
-  - beta still inherits the machine-level `rustup` profile when invoked explicitly, but the build itself remained compatible with the refreshed baseline
+  - the stable lane now follows `rust-toolchain.toml` directly, while `beta` remains an explicit canary job
 - Final replacement and documentation pass completed:
   - local changes supersede the open Dependabot PRs for `reqwest`, `gix`, `gix-object`, `gix-protocol`, `gix-url`, and `github/codeql-action`
   - `.github/workflows/codeql.yaml` now uses `github/codeql-action@v4`

--- a/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
@@ -1,0 +1,66 @@
+## 1. Establish the current baseline
+
+- [x] 1.1 Inventory the current Rust toolchain policy and direct dependency versions.
+- [x] 1.2 Review CI and local validation configuration to identify where toolchain or resolution behavior may currently diverge.
+- [x] 1.3 Decide whether the project should raise, pin, or otherwise explicitly declare the Rust baseline.
+
+## 2. Refresh the Rust toolchain baseline
+
+- [x] 2.1 Apply the intended Rust toolchain policy in repository configuration.
+- [x] 2.2 Update CI or local tooling configuration as needed so the selected baseline is used intentionally.
+- [x] 2.3 Fix compiler or lint fallout introduced by the toolchain change before proceeding to broader dependency work.
+
+## 3. Refresh dependencies in bounded slices
+
+- [x] 3.1 Review direct dependencies in `Cargo.toml` and group them into sensible upgrade slices.
+- [x] 3.2 Apply the first bounded dependency upgrade slice and regenerate `Cargo.lock`.
+- [x] 3.3 Repair API, behavior, formatting, or lint fallout introduced by the upgraded dependencies.
+- [x] 3.4 Repeat for remaining dependency slices until the intended refresh is complete.
+
+## 4. Revalidate the refreshed baseline
+
+- [x] 4.1 Run `cargo test`.
+- [x] 4.2 Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] 4.3 Confirm the PR workflow matrix remains compatible with the refreshed baseline.
+
+## 5. Document the outcome
+
+- [x] 5.1 Summarize the final Rust baseline and major dependency changes.
+- [x] 5.2 Record any deferred upgrades or known follow-up compatibility work.
+
+## Notes
+
+- Baseline inventory completed:
+  - local Rust was already `1.90.0`
+  - the repository had no explicit toolchain file
+  - PR validation used floating `stable` and `beta`
+  - dependency duplicates currently include overlapping HTTP/TLS stacks such as `reqwest 0.11/0.12`, `hyper 0.14/1.x`, and `rustls 0.21/0.23`
+- First implementation slice chosen:
+  - explicitly pin the repository Rust baseline to `1.90.0`
+  - change the CI stable lane from floating `stable` to explicit `1.90.0`
+  - keep `beta` in the matrix as the forward-compatibility canary
+- Toolchain fallout repaired:
+  - the repository initially inherited the local `rustup` `complete` profile, which tried to install unavailable optional components for pinned `1.90.0`
+  - `rust-toolchain.toml` now sets `profile = "minimal"` and explicitly requests only `rustfmt`, `clippy`, and `rust-src`
+  - after that change, `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` both passed under the pinned toolchain
+- First dependency slice completed:
+  - direct dependencies were reviewed and the highest-value slice identified as HTTP/TLS alignment
+  - the repository direct dependency on `reqwest` was upgraded from `0.11` to `0.12`
+  - `Cargo.lock` was regenerated and the duplicate `reqwest`/`hyper`/`rustls` stacks collapsed to a single `0.12` family
+  - no source changes were required; `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` remained green after the upgrade
+- Second dependency slice completed:
+  - core runtime and test utility packages were refreshed in `Cargo.lock`, including `tokio`, `serde`, `serde_json`, `thiserror`, `log`, `once_cell`, `tempfile`, and `serial_test`
+  - the slice stayed bounded to packages behind stable APIs already used throughout the repository
+  - no source changes were required; `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` remained green after the refresh
+- Workflow compatibility spot-check completed:
+  - local `cargo +beta check --bins --tests --verbose` completed successfully, matching the command shape used in the PR workflow
+  - beta still inherits the machine-level `rustup` profile when invoked explicitly, but the build itself remained compatible with the refreshed baseline
+- Final replacement and documentation pass completed:
+  - local changes supersede the open Dependabot PRs for `reqwest`, `gix`, `gix-object`, `gix-protocol`, `gix-url`, and `github/codeql-action`
+  - `.github/workflows/codeql.yaml` now uses `github/codeql-action@v4`
+  - `Cargo.toml` now directly targets `reqwest 0.12`, `gix 0.74`, `gix-object 0.51`, `gix-protocol 0.52`, and `gix-url 0.33.1`
+  - one test helper was updated to the current `gix` API by replacing deprecated `peel_to_commit_in_place()` with `peel_to_commit()`
+  - the final validation baseline remained green with `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`
+- Deferred follow-up notes:
+  - the lockfile still contains some older transitive `gix` family entries, including `gix-url 0.32.0`, because not every indirect dependency path has converged on the latest family yet
+  - the broad `cargo update --dry-run` result remains too large for a single safe refresh pass and should continue as bounded follow-up slices if deeper lockfile freshness is desired

--- a/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
+++ b/openspec/changes/upgrade-toolchain-and-dependencies/tasks.md
@@ -13,7 +13,7 @@
 ## 3. Refresh dependencies in bounded slices
 
 - [x] 3.1 Review direct dependencies in `Cargo.toml` and group them into sensible upgrade slices.
-- [x] 3.2 Apply the first bounded dependency upgrade slice and regenerate `Cargo.lock`.
+- [x] 3.2 Apply the first bounded dependency upgrade slice and refresh the resolved dependency graph under the repository's current no-`Cargo.lock` policy.
 - [x] 3.3 Repair API, behavior, formatting, or lint fallout introduced by the upgraded dependencies.
 - [x] 3.4 Repeat for remaining dependency slices until the intended refresh is complete.
 
@@ -46,10 +46,10 @@
 - First dependency slice completed:
   - direct dependencies were reviewed and the highest-value slice identified as HTTP/TLS alignment
   - the repository direct dependency on `reqwest` was upgraded from `0.11` to `0.12`
-  - `Cargo.lock` was regenerated and the duplicate `reqwest`/`hyper`/`rustls` stacks collapsed to a single `0.12` family
+  - the resolved dependency graph observed during validation collapsed the duplicate `reqwest`/`hyper`/`rustls` stacks to a single `0.12` family
   - no source changes were required; `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` remained green after the upgrade
 - Second dependency slice completed:
-  - core runtime and test utility packages were refreshed in `Cargo.lock`, including `tokio`, `serde`, `serde_json`, `thiserror`, `log`, `once_cell`, `tempfile`, and `serial_test`
+  - core runtime and test utility packages were refreshed in the resolved dependency graph, including `tokio`, `serde`, `serde_json`, `thiserror`, `log`, `once_cell`, `tempfile`, and `serial_test`
   - the slice stayed bounded to packages behind stable APIs already used throughout the repository
   - no source changes were required; `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` remained green after the refresh
 - Workflow compatibility spot-check completed:
@@ -62,5 +62,5 @@
   - one test helper was updated to the current `gix` API by replacing deprecated `peel_to_commit_in_place()` with `peel_to_commit()`
   - the final validation baseline remained green with `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`
 - Deferred follow-up notes:
-  - the lockfile still contains some older transitive `gix` family entries, including `gix-url 0.32.0`, because not every indirect dependency path has converged on the latest family yet
-  - the broad `cargo update --dry-run` result remains too large for a single safe refresh pass and should continue as bounded follow-up slices if deeper lockfile freshness is desired
+  - the resolved dependency graph observed during validation still included some older transitive `gix` family entries, including `gix-url 0.32.0`, because not every indirect dependency path had converged on the latest family yet
+  - the broad `cargo update --dry-run` result remained too large for a single safe refresh pass and should continue as bounded follow-up slices if deeper transitive convergence is desired

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.90.0"
+profile = "minimal"
+components = ["rustfmt", "clippy", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.90.0"
 profile = "minimal"
-components = ["rustfmt", "clippy", "rust-src"]
+components = ["rustfmt", "clippy"]

--- a/src/scanner/tests/manager.rs
+++ b/src/scanner/tests/manager.rs
@@ -603,7 +603,7 @@ async fn test_start_point_resolution() {
 
     // Test resolving specific commit SHA (use first 8 chars of HEAD)
     let repo = gix::open(current_dir.as_path()).unwrap();
-    let head_commit = repo.head().unwrap().peel_to_commit_in_place().unwrap();
+    let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
     let full_sha = head_commit.id().to_hex_with_len(40).to_string();
     let short_sha = &full_sha[..8];
 


### PR DESCRIPTION
## Summary
- pin the repository Rust baseline to `1.90.0` with a repo-local minimal toolchain profile
- update CI validation to use the explicit stable baseline and keep `beta` as a canary
- replace the open Dependabot dependency updates locally in one coherent refresh pass
- record the work in the `upgrade-toolchain-and-dependencies` OpenSpec change

## Included local replacements
- supersedes #51 `reqwest 0.11 -> 0.12`
- supersedes #52 `github/codeql-action v3 -> v4`
- supersedes #53 `gix-url 0.32.0 -> 0.33.1`
- supersedes #54 `gix-protocol 0.51 -> 0.52`
- supersedes #55 `gix-object 0.50 -> 0.51`
- supersedes #56 `gix 0.73 -> 0.74`

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo +beta check --bins --tests --verbose`

## Notes
- one test helper was updated for the newer `gix` API by replacing deprecated `peel_to_commit_in_place()` with `peel_to_commit()`
- some older transitive `gix` family entries still coexist in `Cargo.lock`; the direct dependency PRs are still superseded by this branch

## Summary by Sourcery

Pin the repository to an explicit Rust 1.90.0 toolchain baseline, refresh selected core dependencies, and align CI and documentation with the new baseline.

Enhancements:
- Upgrade core HTTP and Git-related dependencies (including reqwest and gix family crates) to newer compatible versions.
- Introduce an explicit rust-toolchain configuration using a minimal profile with required components.
- Align test helper usage with the updated gix API to remove deprecated calls.
- Document the toolchain and dependency refresh as an OpenSpec change with design, tasks, and requirements specs.

CI:
- Update PR and CodeQL workflows to use the explicit Rust 1.90.0 baseline and CodeQL v4 while retaining beta as a canary lane.

Documentation:
- Add OpenSpec design, proposal, and task documentation describing the toolchain and dependency refresh policy and process.