### PR TITLE
refactor: remove stale dead-code allowances

### DIFF
--- a/openspec/changes/audit-allow-dead-code/tasks.md
+++ b/openspec/changes/audit-allow-dead-code/tasks.md
@@ -9,14 +9,14 @@
 - [x] 2.1 Mark items with no concrete consumer or documented contract as `remove now`.
 - [x] 2.2 Mark items that are still serving an intentional compatibility or documented boundary role as `keep`.
 - [x] 2.3 Mark ambiguous items that affect stable boundary policy as `needs decision`.
-  Remaining scanner/check-out-manager test-support cases were identified as boundary decisions rather than routine dead-code cleanup.
+  Remaining scanner/checkout-manager test-support cases were identified as boundary decisions rather than routine dead-code cleanup.
 
 ## 3. Remove unjustified dead code
 
 - [x] 3.1 Remove unused APIs and helpers classified as `remove now`.
 - [x] 3.2 Remove corresponding `#[allow(dead_code)]` annotations that are no longer needed.
 - [x] 3.3 Narrow any remaining allowances so they apply only to the specific justified item.
-  The remaining allowances are limited to scanner/check-out-manager test-support helpers and a single styles macro case.
+  The remaining allowances are limited to scanner/checkout-manager test-support helpers and a single styles macro case.
 
 ## 4. Handle edge cases explicitly
 
@@ -30,4 +30,4 @@
 - [x] 5.1 Run `cargo clippy --all-targets --all-features -- -D warnings`.
 - [x] 5.2 Run `cargo test`.
 - [x] 5.3 Summarize which allowances were removed, which remained, and why.
-  Most allowances across `core`, `notifications`, `plugin`, and `queue` were removed. The remaining scanner/check-out-manager cases were isolated as a separate test-boundary follow-up, and one `core::styles` allowance remains narrowly scoped to the generated enum variants.
+  Most allowances across `core`, `notifications`, `plugin`, and `queue` were removed. The remaining scanner/checkout-manager cases were isolated as a separate test-boundary follow-up, and one `core::styles` allowance remains narrowly scoped to the generated enum variants.

--- a/openspec/changes/audit-allow-dead-code/tasks.md
+++ b/openspec/changes/audit-allow-dead-code/tasks.md
@@ -1,28 +1,33 @@
 ## 1. Inventory current dead-code allowances
 
-- [ ] 1.1 Enumerate the `#[allow(dead_code)]` annotations added during the recent clippy cleanup pass.
-- [ ] 1.2 Group the findings by subsystem (`core`, `notifications`, `plugin`, `queue`, `scanner`) and by kind (`public boundary`, `compatibility shim`, `test helper`, `internal helper`).
-- [ ] 1.3 Record whether each allowed item has current production use, test use, documentation use, or no clear consumer.
+- [x] 1.1 Enumerate the `#[allow(dead_code)]` annotations added during the recent clippy cleanup pass.
+- [x] 1.2 Group the findings by subsystem (`core`, `notifications`, `plugin`, `queue`, `scanner`) and by kind (`public boundary`, `compatibility shim`, `test helper`, `internal helper`).
+- [x] 1.3 Record whether each allowed item has current production use, test use, documentation use, or no clear consumer.
 
 ## 2. Classify each allowed item
 
-- [ ] 2.1 Mark items with no concrete consumer or documented contract as `remove now`.
-- [ ] 2.2 Mark items that are still serving an intentional compatibility or documented boundary role as `keep`.
-- [ ] 2.3 Mark ambiguous items that affect stable boundary policy as `needs decision`.
+- [x] 2.1 Mark items with no concrete consumer or documented contract as `remove now`.
+- [x] 2.2 Mark items that are still serving an intentional compatibility or documented boundary role as `keep`.
+- [x] 2.3 Mark ambiguous items that affect stable boundary policy as `needs decision`.
+  Remaining scanner/check-out-manager test-support cases were identified as boundary decisions rather than routine dead-code cleanup.
 
 ## 3. Remove unjustified dead code
 
-- [ ] 3.1 Remove unused APIs and helpers classified as `remove now`.
-- [ ] 3.2 Remove corresponding `#[allow(dead_code)]` annotations that are no longer needed.
-- [ ] 3.3 Narrow any remaining allowances so they apply only to the specific justified item.
+- [x] 3.1 Remove unused APIs and helpers classified as `remove now`.
+- [x] 3.2 Remove corresponding `#[allow(dead_code)]` annotations that are no longer needed.
+- [x] 3.3 Narrow any remaining allowances so they apply only to the specific justified item.
+  The remaining allowances are limited to scanner/check-out-manager test-support helpers and a single styles macro case.
 
 ## 4. Handle edge cases explicitly
 
-- [ ] 4.1 For each `needs decision` item, either resolve the decision during the change or record the required follow-up artifact.
-- [ ] 4.2 Confirm that any retained dead-code allowance has a clear reviewable justification.
+- [x] 4.1 For each `needs decision` item, either resolve the decision during the change or record the required follow-up artifact.
+  Follow-up change created: `restrict-scanner-test-api`.
+- [x] 4.2 Confirm that any retained dead-code allowance has a clear reviewable justification.
+  Scanner and checkout-manager cases remain only as temporary, explicit exceptions pending the follow-up boundary cleanup.
 
 ## 5. Re-verify the baseline
 
-- [ ] 5.1 Run `cargo clippy --all-targets --all-features -- -D warnings`.
-- [ ] 5.2 Run `cargo test`.
-- [ ] 5.3 Summarize which allowances were removed, which remained, and why.
+- [x] 5.1 Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] 5.2 Run `cargo test`.
+- [x] 5.3 Summarize which allowances were removed, which remained, and why.
+  Most allowances across `core`, `notifications`, `plugin`, and `queue` were removed. The remaining scanner/check-out-manager cases were isolated as a separate test-boundary follow-up, and one `core::styles` allowance remains narrowly scoped to the generated enum variants.

--- a/openspec/changes/restrict-scanner-test-api/.openspec.yaml
+++ b/openspec/changes/restrict-scanner-test-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/restrict-scanner-test-api/proposal.md
+++ b/openspec/changes/restrict-scanner-test-api/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The scanner subsystem and its supporting checkout manager still expose test and helper entry points that appear to be used to shortcut implementation details rather than exercise observable behaviour. That makes some integration tests depend on internal structure, keeps dead-code allowances alive, and weakens the intended public boundary of the scanner.
+
+This change is needed now because the dead-code audit has isolated the remaining allowances to scanner and checkout-manager test-support surface. The project should decide deliberately whether those entry points belong in the supported API or should be removed, hidden from non-test builds, or replaced with behaviour-oriented test coverage.
+
+## What Changes
+
+- Audit the scanner and checkout-manager test/helper API surface structurally rather than as isolated methods.
+- Identify integration tests that currently rely on non-public or shortcut access paths and refactor them to use public APIs and observable behaviour instead.
+- Remove dead code, hidden shortcuts, and implementation-coupled helper entry points where they are no longer justified.
+- Examine any remaining non-public API use case by case and keep only the cases that cannot reasonably be replaced, with explicit justification.
+
+## Capabilities
+
+### New Capabilities
+- `scanner-test-api-boundary`: Define and enforce the boundary between scanner production APIs, test-only helpers, and behaviour-oriented integration tests.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `src/scanner/task/*`, `src/scanner/checkout/manager.rs`, scanner-related tests in `src/scanner/tests/`, `src/scanner/task/tests/`, `src/scanner/checkout/tests/`, and `tests/`.
+- Affected systems: scanner public API surface, checkout-manager helper surface, integration test design, and remaining dead-code cleanup in the scanner subsystem.

--- a/src/app/cli/display.rs
+++ b/src/app/cli/display.rs
@@ -7,7 +7,6 @@ use std::io::Write;
 use unicode_width::UnicodeWidthStr;
 
 /// Display plugin table to a provided writer for improved testability and composability
-#[allow(dead_code)]
 pub fn display_plugin_table_to_writer<W: Write>(
     plugins: Vec<PluginInfo>,
     use_color: bool,

--- a/src/app/event_controller.rs
+++ b/src/app/event_controller.rs
@@ -141,7 +141,6 @@ impl EventController {
     }
 
     /// Get the number of discovered controllers
-    #[allow(dead_code)]
     pub fn controller_count(&self) -> usize {
         self.discovered_controllers.len()
     }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -14,7 +14,6 @@ use tokio::sync::broadcast;
 #[derive(Debug, Clone)]
 pub struct ControllerConfig {
     pub completion_timeout: Duration,
-    #[allow(dead_code)]
     pub shutdown_timeout: Duration,
 }
 

--- a/src/core/pattern_parser.rs
+++ b/src/core/pattern_parser.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 
 /// File pattern matcher for include/exclude filtering
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct FilePatternMatcher {
     include_patterns: Vec<Pattern>,
     exclude_patterns: Vec<Pattern>,
@@ -18,7 +17,6 @@ pub struct FilePatternMatcher {
 
 impl FilePatternMatcher {
     /// Create a new file pattern matcher from CLI arguments
-    #[allow(dead_code)]
     pub fn new(
         include_patterns: &[String],
         exclude_patterns: &[String],
@@ -55,7 +53,6 @@ impl FilePatternMatcher {
     /// Files matching any exclude pattern or extension are always excluded,
     /// even if they also match an include pattern or extension.
     /// This means exclusion takes precedence over inclusion.
-    #[allow(dead_code)]
     pub fn matches(&self, path: &Path) -> bool {
         // Check excluded patterns first
         for pattern in &self.exclude_patterns {
@@ -121,7 +118,6 @@ impl FilePatternMatcher {
     /// - `is_path_prefix_match("src2/main.rs", "src")` -> `false`
     /// - `is_path_prefix_match("src", "src")` -> `true`
     /// - `is_path_prefix_match("src/nested/file.rs", "src")` -> `true`
-    #[allow(dead_code)]
     fn is_path_prefix_match(path: &Path, prefix: &Path) -> bool {
         // Convert both paths to string representations for consistent comparison
         let path_str = path.to_string_lossy();
@@ -160,7 +156,6 @@ fn parse_patterns(pattern_strings: &[String]) -> Result<Vec<Pattern>, String> {
 }
 
 /// Parse a comma-separated list of extensions
-#[allow(dead_code)]
 pub fn parse_extensions(extensions_str: &str) -> Vec<String> {
     extensions_str
         .split(',')

--- a/src/core/shutdown.rs
+++ b/src/core/shutdown.rs
@@ -29,13 +29,11 @@ impl ShutdownCoordinator {
     }
 
     /// Subscribe to shutdown notifications
-    #[allow(dead_code)]
     pub fn subscribe(&self) -> broadcast::Receiver<()> {
         self.shutdown_tx.subscribe()
     }
 
     /// Trigger shutdown
-    #[allow(dead_code)]
     pub fn trigger_shutdown(&self) {
         // Use Release ordering to synchronize-with all Acquire loads
         // This ensures that any thread checking is_shutdown_requested()
@@ -45,7 +43,6 @@ impl ShutdownCoordinator {
     }
 
     /// Check if shutdown has been requested
-    #[allow(dead_code)]
     pub fn is_shutdown_requested(&self) -> bool {
         // Use Acquire ordering to synchronize-with Release stores
         // This ensures we see the most up-to-date shutdown state
@@ -57,7 +54,6 @@ impl ShutdownCoordinator {
     /// This method automatically sets up signal handlers and coordinates
     /// shutdown for the provided closure, making it appear as if the
     /// closure is "guarded" by shutdown coordination.
-    #[allow(dead_code)]
     pub async fn guard<F, Fut, R, E>(future_fn: F) -> Result<R, E>
     where
         F: FnOnce(broadcast::Receiver<()>) -> Fut,

--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -1,6 +1,5 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-#[allow(dead_code)]
 pub fn title_case(s: &str) -> String {
     s.split_word_bounds()
         .map(|w| {

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -57,7 +57,6 @@ pub fn handle_mutex_poison<T, E>(
 ///
 /// # Returns
 /// The RwLock read guard on success, or an application error on poison/failure
-#[allow(dead_code)]
 pub fn handle_rwlock_read<T, E>(
     result: LockResult<RwLockReadGuard<T>>,
     error_constructor: impl FnOnce(String) -> E,
@@ -83,7 +82,6 @@ pub fn handle_rwlock_read<T, E>(
 ///
 /// # Returns
 /// The RwLock write guard on success, or an application error on poison/failure
-#[allow(dead_code)]
 pub fn handle_rwlock_write<T, E>(
     result: LockResult<RwLockWriteGuard<T>>,
     error_constructor: impl FnOnce(String) -> E,

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use std::time::{Instant, SystemTime};
 
 /// Abstraction over system time for testable time-dependent logic
-#[allow(dead_code)]
 pub trait TimeProvider: Send + Sync {
     /// Get the current monotonic time (for measuring intervals)
     fn now(&self) -> Instant;
@@ -40,7 +39,6 @@ pub struct MockTimeProvider {
 
 #[cfg(test)]
 impl MockTimeProvider {
-    #[allow(dead_code)]
     pub fn new_with_time(instant: Instant, system_time: SystemTime) -> Self {
         Self {
             current_instant: Arc::new(Mutex::new(instant)),

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -20,7 +20,6 @@ impl ValidationError {
         }
     }
 
-    #[allow(dead_code)]
     pub fn details(&self) -> &str {
         &self.details
     }
@@ -103,7 +102,6 @@ where
 }
 
 /// Validate date range arguments (since/until can now handle both ISO 8601 and relative formats)
-#[allow(dead_code)]
 pub fn validate_date_range(
     since: Option<&str>,
     until: Option<&str>,
@@ -125,7 +123,6 @@ pub fn validate_date_range(
 // Reference conflict validation is no longer needed since we only have --ref
 
 /// Validate positive integer value
-#[allow(dead_code)]
 pub fn validate_positive_int(value: &str) -> Result<usize, ValidationError> {
     match value.parse::<usize>() {
         Ok(0) => Err(ValidationError::new("Value must be greater than 0")),
@@ -138,7 +135,6 @@ pub fn validate_positive_int(value: &str) -> Result<usize, ValidationError> {
 }
 
 /// Validate file extension format
-#[allow(dead_code)]
 pub fn validate_extension(ext: &str) -> Result<String, ValidationError> {
     // Remove leading dot if present
     let cleaned = if let Some(stripped) = ext.strip_prefix('.') {
@@ -162,7 +158,6 @@ pub fn validate_extension(ext: &str) -> Result<String, ValidationError> {
 }
 
 /// Validate glob pattern syntax
-#[allow(dead_code)]
 pub fn validate_glob_pattern(pattern: &str) -> Result<String, ValidationError> {
     // Try to compile as glob pattern
     match glob::Pattern::new(pattern) {
@@ -175,7 +170,6 @@ pub fn validate_glob_pattern(pattern: &str) -> Result<String, ValidationError> {
 }
 
 /// Validate filter combinations for logical consistency
-#[allow(dead_code)]
 pub fn validate_filter_combinations(
     include_patterns: &[String],
     exclude_patterns: &[String],

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Build metadata and API version accessors shared across app and plugins.
 //! This includes the generated version.rs from the build script into a core module,
 //! providing a single source of truth.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,12 @@
-use crate::app::event_controller::EventController;
-use crate::core::error_handling::log_error_with_context;
-use crate::notifications::api::{notification_service, Event, SystemEvent, SystemEventType};
-use crate::scanner::api::ScanError;
-
-mod app;
-mod core;
-mod notifications;
-mod plugin;
-mod queue;
-mod scanner;
-use notifications::api::*;
+use repostats::app;
+use repostats::app::event_controller::EventController;
+use repostats::core::error_handling::log_error_with_context;
+use repostats::notifications::api::{
+    notification_service, Event, NotificationError, SystemEvent, SystemEventType,
+};
+use repostats::plugin;
+use repostats::scanner;
+use repostats::scanner::api::ScanError;
 
 // Version access is now provided via crate::core::version
 
@@ -86,7 +83,7 @@ async fn run_scanner_simple(
 ) -> Result<(), ScanError> {
     // Initialize plugin manager
     {
-        if let Err(e) = crate::plugin::api::plugin_service().initialize().await {
+        if let Err(e) = plugin::api::plugin_service().initialize().await {
             log::error!("Failed to initialize plugin manager: {}", e);
             std::process::exit(1);
         }
@@ -116,15 +113,6 @@ async fn system_start(pid: u32) -> Result<(), NotificationError> {
         format!("System started, pid={pid}"),
     ));
     notification_service().publish(startup_event).await
-}
-
-#[allow(dead_code)]
-async fn system_stop(pid: u32) -> Result<(), NotificationError> {
-    let shutdown_event = Event::System(SystemEvent::with_message(
-        SystemEventType::Shutdown,
-        format!("System shutting down, pid={pid}"),
-    ));
-    notification_service().publish(shutdown_event).await
 }
 
 /// Start the actual repository scanner with the configured scanner manager

--- a/src/notifications/api.rs
+++ b/src/notifications/api.rs
@@ -51,7 +51,6 @@ impl NotificationService {
     }
 
     /// Return the current number of event subscribers.
-    #[allow(dead_code)]
     pub async fn subscriber_count(self) -> usize {
         let manager = NOTIFICATION_SERVICE.lock().await;
         manager.subscriber_count()
@@ -78,7 +77,6 @@ impl NotificationService {
 /// # Ok(())
 /// # }
 /// ```
-#[allow(dead_code)]
 pub async fn get_notification_service() -> tokio::sync::MutexGuard<'static, AsyncNotificationManager>
 {
     let guard = NOTIFICATION_SERVICE.lock().await;

--- a/src/notifications/error.rs
+++ b/src/notifications/error.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum NotificationError {
     ChannelClosed(String),
     ChannelFull(String),

--- a/src/notifications/event.rs
+++ b/src/notifications/event.rs
@@ -6,7 +6,6 @@ use std::time::SystemTime;
 use crate::plugin::data_export::PluginDataExport;
 
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum ScanEventType {
     Started,
     Progress,
@@ -18,7 +17,6 @@ pub enum ScanEventType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum QueueEventType {
     Started,
     Shutdown,
@@ -30,7 +28,6 @@ pub enum QueueEventType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum PluginEventType {
     Registered,
     Processing,
@@ -44,7 +41,6 @@ pub enum PluginEventType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum SystemEventType {
     Startup,
     Shutdown,
@@ -54,7 +50,6 @@ pub enum SystemEventType {
 
 /// Individual event types that can be published
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct ScanEvent {
     pub event_type: ScanEventType,
     pub timestamp: SystemTime,
@@ -62,7 +57,6 @@ pub struct ScanEvent {
     pub message: Option<String>,
 }
 
-#[allow(dead_code)]
 impl ScanEvent {
     pub fn new(event_type: ScanEventType, scan_id: String) -> Self {
         Self {
@@ -84,7 +78,6 @@ impl ScanEvent {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct QueueEvent {
     pub event_type: QueueEventType,
     pub timestamp: SystemTime,
@@ -93,7 +86,6 @@ pub struct QueueEvent {
     pub message: Option<String>,
 }
 
-#[allow(dead_code)]
 impl QueueEvent {
     pub fn new(event_type: QueueEventType, queue_id: String) -> Self {
         Self {
@@ -142,7 +134,6 @@ impl QueueEvent {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct PluginEvent {
     pub event_type: PluginEventType,
     pub timestamp: SystemTime,
@@ -152,7 +143,6 @@ pub struct PluginEvent {
     pub data_export: Option<Arc<PluginDataExport>>,
 }
 
-#[allow(dead_code)]
 impl PluginEvent {
     pub fn new(event_type: PluginEventType, plugin_id: String, scan_id: String) -> Self {
         Self {
@@ -216,14 +206,12 @@ impl PluginEvent {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct SystemEvent {
     pub event_type: SystemEventType,
     pub timestamp: SystemTime,
     pub message: Option<String>,
 }
 
-#[allow(dead_code)]
 impl SystemEvent {
     pub fn new(event_type: SystemEventType) -> Self {
         Self {
@@ -244,7 +232,6 @@ impl SystemEvent {
 
 /// Unified event enum that encompasses all event types
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub enum Event {
     Scan(ScanEvent),
     Queue(QueueEvent),
@@ -254,7 +241,6 @@ pub enum Event {
 
 /// Event filtering options for subscribers
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum EventFilter {
     ScanOnly,
     QueueOnly,
@@ -265,7 +251,6 @@ pub enum EventFilter {
     All,
 }
 
-#[allow(dead_code)]
 impl EventFilter {
     /// Check if an event should be accepted by this filter
     pub fn accepts(&self, event: &Event) -> bool {

--- a/src/notifications/manager.rs
+++ b/src/notifications/manager.rs
@@ -21,13 +21,11 @@ const MIN_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(60); // Minimum tim
 const ERROR_RATE_THRESHOLD: f64 = 0.1; // 10% error rate triggers log rate limiting
 const DEFAULT_CHANNEL_CAPACITY: usize = 1000; // Default bounded channel capacity
 
-#[allow(dead_code)]
 enum EventSender {
     Bounded(Sender<Event>),
     Unbounded(UnboundedSender<Event>),
 }
 
-#[allow(dead_code)]
 impl EventSender {
     fn try_send(&self, event: Event) -> Result<(), NotificationError> {
         match self {
@@ -60,7 +58,6 @@ impl EventReceiver {
     }
 }
 
-#[allow(dead_code)]
 struct SubscriberInfo {
     filter: EventFilter,
     source: String,
@@ -68,14 +65,12 @@ struct SubscriberInfo {
     statistics: SubscriberStatistics,
 }
 
-#[allow(dead_code)]
 pub struct HealthAssessment {
     pub high_water_mark_subscribers: Vec<String>,
     pub stale_subscribers: Vec<String>,
     pub error_prone_subscribers: Vec<String>,
 }
 
-#[allow(dead_code)]
 pub struct AsyncNotificationManager {
     subscribers: HashMap<String, SubscriberInfo>,
     time_provider: Arc<dyn TimeProvider>,
@@ -93,7 +88,6 @@ impl Default for AsyncNotificationManager {
     }
 }
 
-#[allow(dead_code)]
 impl AsyncNotificationManager {
     pub fn new() -> Self {
         Self::with_time_provider(Arc::new(SystemTimeProvider))
@@ -114,12 +108,6 @@ impl AsyncNotificationManager {
     // Helper methods for atomic f64 handling
     fn get_error_rate_threshold(&self) -> f64 {
         f64::from_bits(self.error_rate_threshold.load(Ordering::Relaxed))
-    }
-
-    #[allow(dead_code)]
-    fn set_error_rate_threshold(&self, value: f64) {
-        self.error_rate_threshold
-            .store(value.to_bits(), Ordering::Relaxed);
     }
 
     pub fn subscribe(

--- a/src/notifications/traits.rs
+++ b/src/notifications/traits.rs
@@ -1,13 +1,14 @@
 //! Traits for the notification system
 
+#[cfg(test)]
 use crate::notifications::event::Event;
+#[cfg(test)]
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
 use std::time::Instant;
 
 /// Statistics tracking for a subscriber
-#[allow(dead_code)]
 pub struct SubscriberStatistics {
     queue_size: AtomicUsize,
     messages_processed: AtomicUsize,
@@ -23,7 +24,6 @@ impl Default for SubscriberStatistics {
     }
 }
 
-#[allow(dead_code)]
 impl SubscriberStatistics {
     pub fn new() -> Self {
         Self {
@@ -98,8 +98,8 @@ impl SubscriberStatistics {
 }
 
 /// Trait for event subscribers
+#[cfg(test)]
 #[async_trait]
-#[allow(dead_code)]
 pub trait Subscriber: Send + Sync {
     /// Handle an incoming event
     async fn handle_event(&self, event: Event) -> Result<(), Box<dyn std::error::Error>>;

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -58,7 +58,6 @@ impl PluginService {
     }
 
     /// Return the current plugin API version.
-    #[allow(dead_code)]
     pub async fn api_version(self) -> u32 {
         let manager = PLUGIN_SERVICE.lock().await;
         manager.api_version()
@@ -151,7 +150,6 @@ impl PluginService {
 /// # Ok(())
 /// # }
 /// ```
-#[allow(dead_code)]
 pub async fn get_plugin_service() -> tokio::sync::MutexGuard<'static, PluginManager> {
     let guard = PLUGIN_SERVICE.lock().await;
     guard

--- a/src/plugin/args.rs
+++ b/src/plugin/args.rs
@@ -39,7 +39,6 @@ impl PluginConfig {
     }
 
     /// Get a boolean configuration value with default
-    #[allow(dead_code)]
     pub fn get_bool(&self, key: &str, default: bool) -> bool {
         if let Some(toml::Value::Boolean(b)) = self.toml_config.get(key) {
             *b
@@ -50,7 +49,6 @@ impl PluginConfig {
 
     /// Set a string configuration value (for testing)
     #[cfg(test)]
-    #[allow(dead_code)]
     pub fn set_string(&mut self, key: &str, value: &str) {
         self.toml_config
             .insert(key.to_string(), toml::Value::String(value.to_string()));

--- a/src/plugin/builtin/dump/consumer.rs
+++ b/src/plugin/builtin/dump/consumer.rs
@@ -149,7 +149,6 @@ impl DumpPlugin {
         }
     }
 
-    #[allow(dead_code)]
     pub(super) async fn stop_consumer_loop(&mut self) -> PluginResult<()> {
         // Send shutdown signal
         if let Some(tx) = self.shutdown_tx.take() {

--- a/src/plugin/builtin/output/traits.rs
+++ b/src/plugin/builtin/output/traits.rs
@@ -46,7 +46,6 @@ impl ExportFormat {
         }
     }
 
-    #[allow(dead_code)]
     pub fn mimetype(&self) -> &'static str {
         match self {
             Self::Text => "text/plain",
@@ -87,7 +86,6 @@ impl ExportFormat {
     }
 
     /// Public iterator over all ExportFormat variants (stable API surface)
-    #[allow(dead_code)]
     pub fn formats() -> impl Iterator<Item = ExportFormat> {
         ExportFormat::iter()
     }
@@ -97,13 +95,11 @@ impl ExportFormat {
     }
 
     /// Get the default file extension for this format
-    #[allow(dead_code)]
     pub fn file_ext(&self) -> &'static str {
         self.name()
     }
 
     /// Get the common file extensions for this format
-    #[allow(dead_code)]
     pub fn file_exts(&self) -> impl Iterator<Item = &str> {
         std::iter::once(self.file_ext()).chain(self.aliases().iter().copied())
     }
@@ -121,7 +117,6 @@ impl ExportFormat {
         Self::Text
     }
 
-    #[allow(dead_code)]
     pub fn from_ext(ext: &str) -> Self {
         Self::from_str(ext)
     }

--- a/src/plugin/data_export.rs
+++ b/src/plugin/data_export.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Data export structures for plugin data interchange
 //!
 //! This module defines the data structures used for exchanging data between

--- a/src/plugin/error.rs
+++ b/src/plugin/error.rs
@@ -79,7 +79,6 @@ impl PluginError {
     ///
     /// This method allows recovery of the original error type from wrapped errors,
     /// enabling more specific error handling when needed.
-    #[allow(dead_code)]
     pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
         use std::any::{Any, TypeId};
 
@@ -114,7 +113,6 @@ impl PluginError {
     ///
     /// This method allows recovery of the original error by consuming the PluginError,
     /// useful when you need owned access to the underlying error.
-    #[allow(dead_code)]
     pub fn downcast<T: std::error::Error + 'static>(self) -> Result<T, Self> {
         use std::any::TypeId;
 

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -24,15 +24,12 @@ use toml::Table;
 #[derive(Clone, Debug)]
 pub struct PluginManagerConfig {
     /// Timeout for waiting for plugin completion events
-    #[allow(dead_code)]
     pub completion_event_timeout: Duration,
 
     /// Maximum time to wait for all plugins to complete during shutdown
-    #[allow(dead_code)]
     pub shutdown_timeout: Duration,
 
     /// Check interval for plugin completion status
-    #[allow(dead_code)]
     pub completion_check_interval: Duration,
 
     /// Maximum time to wait for plugin completion with keep-alive reset capability
@@ -52,7 +49,6 @@ impl Default for PluginManagerConfig {
 
 impl PluginManagerConfig {
     /// Create configuration with custom timeouts
-    #[allow(dead_code)]
     pub fn with_timeouts(
         completion_event_timeout: Duration,
         shutdown_timeout: Duration,
@@ -70,7 +66,6 @@ impl PluginManagerConfig {
     }
 
     /// Validate that plugin timeout meets minimum requirements (5 seconds)
-    #[allow(dead_code)]
     pub fn validate(&self) -> Result<(), String> {
         if self.plugin_timeout < Duration::from_secs(5) {
             return Err("Plugin timeout must be at least 5 seconds".to_string());
@@ -103,12 +98,10 @@ pub struct PluginManager {
 
     /// Plugin coordination state for shutdown management
     /// Tracks whether plugins are in process of shutdown
-    #[allow(dead_code)]
     shutdown_requested: Arc<AtomicBool>,
 
     /// Plugin completion tracking
     /// Maps plugin name to completion status
-    #[allow(dead_code)]
     plugin_completion: Arc<RwLock<HashMap<String, bool>>>,
 
     /// Configuration for timeouts and thresholds
@@ -128,7 +121,6 @@ pub struct PluginManager {
 
 impl PluginManager {
     /// Error message for plugin event subscription not initialized
-    #[allow(dead_code)]
     const EVENT_SUBSCRIPTION_ERROR: &'static str =
         "Plugin event subscription not initialized. Call initialize() first.";
 
@@ -454,19 +446,16 @@ impl PluginManager {
     ///
     /// Returns the TOML configuration table for the specified plugin,
     /// or None if no configuration was found.
-    #[allow(dead_code)]
     pub fn get_plugin_config(&self, plugin_name: &str) -> Option<&Table> {
         self.plugin_configs.get(plugin_name)
     }
 
     /// Check if a plugin has configuration
-    #[allow(dead_code)]
     pub fn has_plugin_config(&self, plugin_name: &str) -> bool {
         self.plugin_configs.contains_key(plugin_name)
     }
 
     /// Get all plugin configurations
-    #[allow(dead_code)]
     pub fn get_all_plugin_configs(&self) -> &HashMap<String, Table> {
         &self.plugin_configs
     }
@@ -575,7 +564,6 @@ impl PluginManager {
     }
 
     /// Notify all active plugins about system shutdown
-    #[allow(dead_code)]
     pub async fn notify_plugins_shutdown(&self) -> PluginResult<()> {
         use crate::notifications::api::PluginEvent;
         use crate::notifications::event::{Event, PluginEventType};
@@ -647,7 +635,6 @@ impl PluginManager {
     ///
     /// This implementation uses the pre-subscribed event receiver to eliminate race conditions.
     /// Supports keep-alive events to extend timeout for long-running operations.
-    #[allow(dead_code)]
     pub async fn await_all_plugins_completion(&self) -> PluginResult<()> {
         log::trace!("Starting await_all_plugins_completion");
 
@@ -849,7 +836,6 @@ impl PluginManager {
     /// This method is similar to await_all_plugins_completion() but also listens
     /// for shutdown signals and can be interrupted gracefully. This solves the
     /// signal handling integration issue during plugin completion wait.
-    #[allow(dead_code)]
     pub async fn await_all_plugins_completion_with_shutdown(
         &self,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
@@ -911,7 +897,6 @@ impl PluginManager {
     /// This method signals all active plugins to stop processing and waits
     /// for them to complete within the specified timeout. Returns a summary
     /// of which plugins completed vs timed out.
-    #[allow(dead_code)]
     pub async fn graceful_stop_all(
         &self,
         stop_timeout: Duration,
@@ -990,13 +975,11 @@ impl PluginManager {
     }
 
     /// Check if shutdown has been requested
-    #[allow(dead_code)]
     pub fn is_shutdown_requested(&self) -> bool {
         self.shutdown_requested.load(Ordering::Acquire)
     }
 
     /// Mark a plugin as completed (for use by plugins to signal completion)
-    #[allow(dead_code)]
     pub async fn mark_plugin_completed(&self, plugin_name: &str) {
         let mut completion = self.plugin_completion.write().await;
         completion.insert(plugin_name.to_string(), true);
@@ -1004,7 +987,6 @@ impl PluginManager {
 
     /// Remove all completed plugins from the tracking map
     /// This prevents memory leaks by cleaning up completed entries
-    #[allow(dead_code)]
     pub async fn cleanup_completed_plugins(&self) {
         let mut completion = self.plugin_completion.write().await;
         let initial_count = completion.len();
@@ -1031,7 +1013,6 @@ impl PluginManager {
 
     /// Get count of plugins currently being tracked for completion
     /// Useful for monitoring and debugging
-    #[allow(dead_code)]
     pub async fn get_pending_completion_count(&self) -> usize {
         let completion = self.plugin_completion.read().await;
         completion.len()
@@ -1040,7 +1021,6 @@ impl PluginManager {
 
 /// Summary of plugin stop operation results
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct PluginStopSummary {
     /// Plugins that completed gracefully
     pub completed: Vec<String>,
@@ -1052,7 +1032,6 @@ pub struct PluginStopSummary {
 
 impl PluginStopSummary {
     /// Create an empty summary
-    #[allow(dead_code)]
     pub fn empty() -> Self {
         Self {
             completed: Vec::new(),
@@ -1062,13 +1041,11 @@ impl PluginStopSummary {
     }
 
     /// Check if all plugins completed successfully
-    #[allow(dead_code)]
     pub fn all_completed(&self) -> bool {
         self.timed_out.is_empty() && self.errors.is_empty()
     }
 
     /// Get total number of plugins that were stopped
-    #[allow(dead_code)]
     pub fn total_plugins(&self) -> usize {
         self.completed.len() + self.timed_out.len() + self.errors.len()
     }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -56,7 +56,6 @@ impl PluginRegistry {
     }
 
     /// Remove a plugin from the registry
-    #[allow(dead_code)]
     pub fn deregister_plugin(&mut self, name: &str) -> PluginResult<()> {
         if self.active_plugins.contains(name) {
             self.active_plugins.remove(name);
@@ -93,7 +92,6 @@ impl PluginRegistry {
     }
 
     /// Deactivate a plugin (mark it as inactive)
-    #[allow(dead_code)]
     pub fn deactivate_plugin(&mut self, name: &str) -> PluginResult<()> {
         if !self.has_plugin(name) {
             Err(PluginError::PluginNotFound {
@@ -139,20 +137,17 @@ impl PluginRegistry {
     }
 
     /// Check if a plugin is currently active
-    #[allow(dead_code)]
     pub fn is_plugin_active(&self, name: &str) -> bool {
         self.active_plugins.contains(name)
     }
 
     /// Clear all active plugins
-    #[allow(dead_code)]
     pub fn clear_active_plugins(&mut self) {
         self.active_plugins.clear();
     }
 
     /// Get the plugin type for a registered plugin
     /// Helper method for uniqueness constraint enforcement
-    #[allow(dead_code)]
     pub fn get_plugin_type(&self, name: &str) -> PluginResult<PluginType> {
         if let Some(plugin) = self.plugins.get(name) {
             Ok(plugin.plugin_info().plugin_type)
@@ -164,13 +159,11 @@ impl PluginRegistry {
     }
 
     /// Get total count of registered plugins
-    #[allow(dead_code)]
     pub fn plugin_count(&self) -> usize {
         self.plugins.len()
     }
 
     /// Clear all plugins from registry
-    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.plugins.clear();
         self.active_plugins.clear();
@@ -178,7 +171,6 @@ impl PluginRegistry {
     }
 
     /// Execute a plugin with execution token pattern to prevent concurrent execution
-    #[allow(dead_code)]
     pub async fn execute_plugin(&mut self, name: &str) -> PluginResult<()> {
         // Check if already executing
         if self.executing.contains(name) {
@@ -209,7 +201,6 @@ impl PluginRegistry {
     }
 
     /// Check if a plugin is currently executing
-    #[allow(dead_code)]
     pub fn is_plugin_executing(&self, name: &str) -> bool {
         self.executing.contains(name)
     }
@@ -249,35 +240,30 @@ impl SharedPluginRegistry {
     }
 
     /// Convenience method to check if plugin exists
-    #[allow(dead_code)]
     pub async fn has_plugin(&self, name: &str) -> bool {
         let registry = self.inner.read().await;
         registry.has_plugin(name)
     }
 
     /// Convenience method to get plugin names
-    #[allow(dead_code)]
     pub async fn get_plugin_names(&self) -> Vec<String> {
         let registry = self.inner.read().await;
         registry.get_plugin_names()
     }
 
     /// Convenience method to get plugin count
-    #[allow(dead_code)]
     pub async fn plugin_count(&self) -> usize {
         let registry = self.inner.read().await;
         registry.plugin_count()
     }
 
     /// Convenience method to get active plugin names
-    #[allow(dead_code)]
     pub async fn get_active_plugins(&self) -> Vec<String> {
         let registry = self.inner.read().await;
         registry.get_active_plugins()
     }
 
     /// Convenience method to activate a plugin
-    #[allow(dead_code)]
     pub async fn activate_plugin(&self, name: &str) -> PluginResult<()> {
         log::trace!("SharedPluginRegistry: activating plugin '{}'", name);
         let mut registry = self.inner.write().await;
@@ -285,7 +271,6 @@ impl SharedPluginRegistry {
     }
 
     /// Convenience method to deactivate a plugin
-    #[allow(dead_code)]
     async fn deactivate_plugin(&self, name: &str) -> PluginResult<()> {
         log::trace!("SharedPluginRegistry: deactivating plugin '{}'", name);
         let mut registry = self.inner.write().await;
@@ -331,7 +316,6 @@ impl SharedPluginRegistry {
     }
 
     /// Deactivate a plugin and publish Unregistered event
-    #[allow(dead_code)]
     pub async fn deregister_plugin_with_notification(&self, name: &str) -> PluginResult<()> {
         log::trace!(
             "SharedPluginRegistry: deactivating plugin '{}' with notification",
@@ -365,14 +349,12 @@ impl SharedPluginRegistry {
     }
 
     /// Convenience method to check if plugin is active
-    #[allow(dead_code)]
     pub async fn is_plugin_active(&self, name: &str) -> bool {
         let registry = self.inner.read().await;
         registry.is_plugin_active(name)
     }
 
     /// Convenience method to clear all active plugins
-    #[allow(dead_code)]
     pub async fn clear_active_plugins(&self) {
         let mut registry = self.inner.write().await;
         registry.clear_active_plugins();
@@ -418,7 +400,6 @@ impl SharedPluginRegistry {
     }
 
     /// Check if a plugin is currently executing
-    #[allow(dead_code)]
     pub async fn is_plugin_executing(&self, name: &str) -> bool {
         let registry = self.inner.read().await;
         registry.is_plugin_executing(name)

--- a/src/plugin/traits.rs
+++ b/src/plugin/traits.rs
@@ -36,11 +36,9 @@ pub trait Plugin: Send + Sync {
     fn plugin_info(&self) -> PluginInfo;
 
     /// Get plugin type
-    #[allow(dead_code)]
     fn plugin_type(&self) -> PluginType;
 
     /// Get list of functions this plugin advertises
-    #[allow(dead_code)]
     fn advertised_functions(&self) -> Vec<String>;
 
     /// Get scanner requirements for this plugin
@@ -77,7 +75,6 @@ pub trait Plugin: Send + Sync {
     async fn execute(&mut self) -> PluginResult<()>;
 
     /// Clean up plugin resources
-    #[allow(dead_code)]
     async fn cleanup(&mut self) -> PluginResult<()>;
 
     /// Parse plugin-specific command line arguments with configuration context
@@ -89,7 +86,6 @@ pub trait Plugin: Send + Sync {
 
     /// Attempt to get this plugin as a ConsumerPlugin if it implements that trait
     /// Returns None if this plugin is not a ConsumerPlugin
-    #[allow(dead_code)]
     fn as_consumer_plugin(&mut self) -> Option<&mut dyn ConsumerPlugin> {
         None // Default implementation - plugins that implement ConsumerPlugin should override this
     }
@@ -115,7 +111,6 @@ pub trait ConsumerPlugin: Plugin {
     async fn inject_consumer(&mut self, consumer: QueueConsumer) -> PluginResult<()>;
 
     /// Override the default Plugin implementation to return self as ConsumerPlugin
-    #[allow(dead_code)]
     fn as_consumer_plugin(&mut self) -> Option<&mut dyn ConsumerPlugin>
     where
         Self: Sized,

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -41,6 +41,5 @@ pub struct PluginInfo {
 pub enum PluginType {
     Processing,
     Output,
-    #[allow(dead_code)]
     Notification,
 }

--- a/src/queue/api.rs
+++ b/src/queue/api.rs
@@ -47,7 +47,6 @@ impl QueueService {
     }
 
     /// Create a consumer on the global queue service.
-    #[allow(dead_code)]
     pub fn create_consumer(self, plugin_name: String) -> QueueResult<QueueConsumer> {
         QUEUE_SERVICE.create_consumer(plugin_name)
     }
@@ -73,7 +72,6 @@ impl QueueService {
 /// # Ok(())
 /// # }
 /// ```
-#[allow(dead_code)]
 pub fn get_queue_service() -> Arc<QueueManager> {
     queue_service().manager()
 }

--- a/src/queue/consumer.rs
+++ b/src/queue/consumer.rs
@@ -38,9 +38,7 @@ use std::sync::{Arc, Weak};
 /// # }
 /// ```
 pub struct QueueConsumer {
-    #[allow(dead_code)]
     consumer_id: String,
-    #[allow(dead_code)]
     plugin_name: String,
     manager: Weak<QueueManager>,
     internal_consumer_id: u64,
@@ -69,18 +67,15 @@ impl QueueConsumer {
         Ok(consumer)
     }
 
-    #[allow(dead_code)]
     pub fn consumer_id(&self) -> &str {
         &self.consumer_id
     }
 
-    #[allow(dead_code)]
     pub fn plugin_name(&self) -> &str {
         &self.plugin_name
     }
 
     /// Get the internal consumer ID (used for queue position tracking)
-    #[allow(dead_code)]
     pub fn internal_consumer_id(&self) -> u64 {
         self.internal_consumer_id
     }
@@ -101,7 +96,6 @@ impl QueueConsumer {
     }
 
     /// Read a batch of messages from the global queue for improved performance
-    #[allow(dead_code)]
     pub fn read_batch(&self, batch_size: usize) -> QueueResult<Vec<Arc<Message>>> {
         let mut batch = Vec::with_capacity(batch_size);
 
@@ -118,7 +112,6 @@ impl QueueConsumer {
 
     /// Acknowledge a batch of messages (currently a no-op for compatibility)
     /// In a full implementation, this would be used for at-least-once delivery guarantees
-    #[allow(dead_code)]
     pub fn acknowledge_batch(&self, _messages: &[Arc<Message>]) -> QueueResult<usize> {
         // For now, just return the count of messages "acknowledged"
         // In a production system, this would update consumer commits/offsets

--- a/src/queue/error.rs
+++ b/src/queue/error.rs
@@ -9,11 +9,9 @@ pub enum QueueError {
     ConsumerNotFound { consumer_id: String },
 
     #[error("Producer not found: {producer_id}")]
-    #[allow(dead_code)]
     ProducerNotFound { producer_id: String },
 
     #[error("Sequence out of bounds: {sequence}")]
-    #[allow(dead_code)]
     SequenceOutOfBounds { sequence: u64 },
 
     #[error("Operation failed: {message}")]

--- a/src/queue/internal.rs
+++ b/src/queue/internal.rs
@@ -43,7 +43,6 @@ pub struct MultiConsumerQueue {
     max_size: usize,
 
     /// Queue identifier
-    #[allow(dead_code)]
     queue_id: String,
 }
 
@@ -60,13 +59,11 @@ impl MultiConsumerQueue {
     }
 
     /// Get the queue identifier
-    #[allow(dead_code)]
     pub fn queue_id(&self) -> &str {
         &self.queue_id
     }
 
     /// Get current queue size (number of messages)
-    #[allow(dead_code)]
     pub fn size(&self) -> QueueResult<usize> {
         let messages =
             handle_mutex_poison(self.messages.read(), |msg| QueueError::OperationFailed {
@@ -76,7 +73,6 @@ impl MultiConsumerQueue {
     }
 
     /// Get the current head sequence number (next message to be assigned)
-    #[allow(dead_code)]
     pub fn head_sequence(&self) -> QueueResult<u64> {
         let sequence = handle_mutex_poison(self.next_sequence.read(), |msg| {
             QueueError::OperationFailed {
@@ -87,7 +83,6 @@ impl MultiConsumerQueue {
     }
 
     /// Get the minimum sequence across all consumers (for garbage collection)
-    #[allow(dead_code)]
     pub fn min_consumer_sequence(&self) -> QueueResult<Option<u64>> {
         let positions = handle_mutex_poison(self.consumer_positions.read(), |msg| {
             QueueError::OperationFailed {
@@ -141,7 +136,6 @@ impl MultiConsumerQueue {
     }
 
     /// Get all registered consumer IDs
-    #[allow(dead_code)]
     pub fn consumer_ids(&self) -> QueueResult<Vec<u64>> {
         let positions = handle_mutex_poison(self.consumer_positions.read(), |msg| {
             QueueError::OperationFailed {
@@ -257,7 +251,6 @@ impl MultiConsumerQueue {
     }
 
     /// Check if consumer exists
-    #[allow(dead_code)]
     pub fn has_consumer(&self, consumer_id: u64) -> bool {
         handle_rwlock_read(self.consumer_positions.read(), |_| {
             QueueError::OperationFailed {
@@ -269,7 +262,6 @@ impl MultiConsumerQueue {
     }
 
     /// Get consumer position information
-    #[allow(dead_code)]
     pub fn consumer_position(&self, consumer_id: u64) -> Option<u64> {
         handle_rwlock_read(self.consumer_positions.read(), |_| {
             QueueError::OperationFailed {
@@ -284,7 +276,6 @@ impl MultiConsumerQueue {
     }
 
     /// Get consumer's last read timestamp
-    #[allow(dead_code)]
     pub fn consumer_last_read_time(
         &self,
         consumer_id: u64,
@@ -302,7 +293,6 @@ impl MultiConsumerQueue {
     /// Perform garbage collection based on consumer positions
     /// Removes messages that have been read by all consumers
     /// Returns the number of messages collected
-    #[allow(dead_code)]
     pub fn collect_garbage(&self) -> QueueResult<usize> {
         // Find the minimum sequence number across all consumers
         let min_sequence = match self.min_consumer_sequence()? {

--- a/src/queue/manager.rs
+++ b/src/queue/manager.rs
@@ -56,7 +56,6 @@ pub struct QueueManager {
 
 impl QueueManager {
     const GLOBAL_QUEUE_ID: &'static str = "global";
-    #[allow(dead_code)]
     const EVENT_PUBLISH_TIMEOUT: Duration = Duration::from_millis(100);
 
     pub fn new() -> Self {
@@ -88,7 +87,6 @@ impl QueueManager {
     ///
     /// This method publishes lifecycle events with a timeout to prevent deadlocks.
     /// Event publishing failures are logged but do not prevent queue operations.
-    #[allow(dead_code)]
     async fn publish_lifecycle_event(
         &self,
         event_type: QueueEventType,
@@ -178,7 +176,6 @@ impl QueueManager {
     /// // Queue system is now ready for use
     /// # }
     /// ```
-    #[allow(dead_code)]
     pub async fn create() -> Arc<Self> {
         let manager = Arc::new(Self::new());
         // Publish Started event with timeout protection
@@ -224,32 +221,27 @@ impl QueueManager {
     }
 
     /// Legacy method for compatibility - always returns the global queue
-    #[allow(dead_code)]
     pub fn get_queue(&self, _producer_id: &str) -> QueueResult<Arc<MultiConsumerQueue>> {
         Ok(Arc::clone(&self.global_queue))
     }
 
     /// Get number of queues managed (always 1 for single global queue)
-    #[allow(dead_code)]
     pub fn queue_count(&self) -> usize {
         1
     }
 
     /// Get total number of messages in the global queue
-    #[allow(dead_code)]
     pub fn total_message_count(&self) -> QueueResult<usize> {
         self.global_queue.size()
     }
 
     /// Get list of producer IDs that have published messages (not applicable for global queue)
     /// This method is kept for compatibility but doesn't make much sense with single queue
-    #[allow(dead_code)]
     pub fn producer_ids(&self) -> Vec<String> {
         vec!["global".to_string()] // Just return the global queue identifier
     }
 
     /// Get the number of active consumers
-    #[allow(dead_code)]
     pub fn active_consumer_count(&self) -> QueueResult<usize> {
         let consumer_ids = self.global_queue.consumer_ids()?;
         Ok(consumer_ids.len())
@@ -274,7 +266,6 @@ impl QueueManager {
     /// manager.shutdown().await;
     /// # }
     /// ```
-    #[allow(dead_code)]
     pub async fn shutdown(&self) {
         // Publish Shutdown event with timeout protection
         let _ = self

--- a/src/queue/publisher.rs
+++ b/src/queue/publisher.rs
@@ -37,7 +37,6 @@ use std::sync::Weak;
 /// ```
 #[derive(Debug, Clone)]
 pub struct QueuePublisher {
-    #[allow(dead_code)]
     producer_id: String,
     manager: Weak<QueueManager>,
 }
@@ -50,7 +49,6 @@ impl QueuePublisher {
         }
     }
 
-    #[allow(dead_code)]
     pub fn producer_id(&self) -> &str {
         &self.producer_id
     }

--- a/src/queue/traits.rs
+++ b/src/queue/traits.rs
@@ -40,7 +40,6 @@
 ///     }
 /// }
 /// ```
-#[allow(dead_code)]
 pub trait GroupedMessage {
     /// Get the group identifier for this message
     ///

--- a/src/scanner/types.rs
+++ b/src/scanner/types.rs
@@ -35,19 +35,16 @@ impl ScanRequires {
     pub const FILE_INFO: Self = Self((1 << 6) | Self::FILE_CHANGES.0);
 
     /// Create from raw bits
-    #[allow(dead_code)]
     pub const fn from_bits(bits: u64) -> Self {
         Self(bits)
     }
 
     /// Get raw bits
-    #[allow(dead_code)]
     pub const fn bits(&self) -> u64 {
         self.0
     }
 
     /// Check if no requirements are set
-    #[allow(dead_code)]
     pub const fn is_empty(&self) -> bool {
         self.0 == 0
     }
@@ -68,7 +65,6 @@ impl ScanRequires {
     }
 
     /// Remove requirements
-    #[allow(dead_code)]
     pub const fn difference(&self, other: Self) -> Self {
         Self(self.0 & !other.0)
     }


### PR DESCRIPTION
## Summary
- remove stale `#[allow(dead_code)]` annotations across core, notifications, plugin, queue, app, and shared utility code
- switch `src/main.rs` to consume the library crate instead of shadow-defining the module tree in the binary
- record the remaining scanner/check-out-manager boundary work as a follow-up OpenSpec change: `restrict-scanner-test-api`

## Verification
- `cargo check --all-targets --all-features`
- `cargo nextest run`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes
- scanner/check-out-manager test-surface cleanup is intentionally deferred to the separate follow-up change rather than being folded into this dead-code audit
- review artifact created at `.todo/audit-allow-dead-code-review.md`

## Summary by Sourcery

Remove stale dead-code allowances across core subsystems and document remaining scanner/checkout-manager boundary work as a follow-up spec change.

Enhancements:
- Clean up unused `#[allow(dead_code)]` annotations and rely on actual usage to justify remaining API surface across core, notifications, plugin, queue, scanner, and app modules.
- Tighten the public and internal API boundaries by making previously test-only or helper types and methods regular, justified APIs where still in use, and eliminating unused configuration fields and helpers.
- Simplify the binary by using the library crate’s module tree in `main` instead of shadowing it with local definitions.

Documentation:
- Add an OpenSpec change proposal `restrict-scanner-test-api` to track restructuring of the scanner and checkout-manager test API boundary and the remaining dead-code cleanup there.